### PR TITLE
Fix the docusaurus build

### DIFF
--- a/.idea/csp-test.iml
+++ b/.idea/csp-test.iml
@@ -41,6 +41,8 @@
       <excludeFolder url="file://$MODULE_DIR$/js/sdks/packages/server-common/build" />
       <excludeFolder url="file://$MODULE_DIR$/js/sdks/packages/secure-frame-iframe/public/js" />
       <excludeFolder url="file://$MODULE_DIR$/js/demo-apps/packages/express-back-end/build" />
+      <excludeFolder url="file://$MODULE_DIR$/docs/build" />
+      <excludeFolder url="file://$MODULE_DIR$/docs/.docusaurus" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -7,6 +7,8 @@
 # Generated files
 .docusaurus
 .cache-loader
+pages/node-sdk
+pages/react-sdk
 
 # Misc
 .DS_Store

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -22,7 +22,8 @@ module.exports = {
         tsconfig: '../js/sdks/packages/react-sdk/tsconfig.json',
         watch: process.env.TYPEDOC_WATCH,
         // Without this, our URL becomes `lunasec.io/docs/docs`. I prefer `lunasec.io/docs/pages`.
-        out: '../pages/react-sdk',
+        docsRoot: 'pages',
+        out: 'react-sdk',
         sidebar: {
           categoryLabel: "React SDK"
         }
@@ -36,7 +37,8 @@ module.exports = {
         tsconfig: '../js/sdks/packages/node-sdk/tsconfig.json',
         watch: process.env.TYPEDOC_WATCH,
         // Without this, our URL becomes `lunasec.io/docs/docs`. I prefer `lunasec.io/docs/pages`.
-        out: '../pages/node-sdk',
+        docsRoot: 'pages',
+        out: 'node-sdk',
         sidebar: {
           categoryLabel: "Node SDK"
         }
@@ -116,6 +118,8 @@ module.exports = {
       '@docusaurus/preset-classic',
       {
         docs: {
+          path: 'pages',
+          routeBasePath: 'pages',
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           editUrl:


### PR DESCRIPTION
Alright, I fixed the build so that we can use `pages` properly. I read the source code for the plugin to find this option.

Question: Is there any reason for `pages/react-sdk` and `pages/node-sdk` to be committed? I ran a `yarn run build` locally and all of the files are modified in that folder.

Is it possible for us to "add" docs into those folders and have TSDoc live happily alongside them? Or is it fucked and the files will be blown away every time a build happens?