### PR TITLE
inline global used for tokenizer url in iframe

### DIFF
--- a/go/config/tokenizerbackend/config.yaml
+++ b/go/config/tokenizerbackend/config.yaml
@@ -25,6 +25,7 @@ session_controller:
 secure_frame_controller:
   views_path: ${SECURE_FRAME_VIEWS_PATH:views/tokenizerbackend}
   cdn_config: ${SECURE_FRAME_CDN_CONFIG}
+  iframe_backend_url: ${IFRAME_BACKEND_URL:""} # the url that the iframe will use to call back into the tokenizer, defaults to window.location if left empty
 tokenizer:
   secret_arn: ${TOKENIZER_SECRET_ARN:""}
 auth_jwt_verifier:

--- a/go/controller/secureframe.go
+++ b/go/controller/secureframe.go
@@ -39,6 +39,7 @@ type secureFrameController struct {
 type SecureFrameControllerConfig struct {
 	ViewsPath string          `yaml:"views_path"`
 	CdnConfig types.CDNConfig `yaml:"cdn_config"`
+	IframeBackendUrl string   `yaml:"iframe_backend_url"`
 }
 
 type SecureFrameController interface {
@@ -114,6 +115,7 @@ func (s *secureFrameController) Frame(w http.ResponseWriter, r *http.Request) {
 		RequestNonce:  nonce,
 		ScriptUrl:     scriptURL.String(),
 		StyleUrl:      styleURL.String(),
+		BackendUrl:    s.SecureFrameControllerConfig.IframeBackendUrl,
 	}
 
 	w.Header().Set("Content-Type", "text/html")

--- a/go/types/secureframe.go
+++ b/go/types/secureframe.go
@@ -33,4 +33,5 @@ type FrameVars struct {
 	InputStyle    string
 	ScriptUrl     string
 	StyleUrl      string
+	BackendUrl    string
 }

--- a/go/views/tokenizerbackend/index.pug
+++ b/go/views/tokenizerbackend/index.pug
@@ -5,5 +5,9 @@ html
   body
     h1.d-none Secure Frame
     span.loading-text Loading...
+    script(type="text/javascript", nonce=.CSPNonce).
+        // BEGIN INLINE GLOBALS
+        window.LUNASEC_BACKEND_URL = "#{.BackendUrl}"
+        // END INLINE GLOBALS
     script(src=.ScriptUrl, nonce=.CSPNonce)
 

--- a/js/sdks/packages/secure-frame-iframe/src/secure-frame.ts
+++ b/js/sdks/packages/secure-frame-iframe/src/secure-frame.ts
@@ -23,9 +23,16 @@ import { initializeUploader } from './initialize-uploader';
 import { iFrameRPC } from './rpc';
 import { handleDownload } from './secure-download';
 import { validate } from './validators';
+
 export type SupportedElement = TagLookup[keyof TagLookup];
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare global {
+  interface Window {
+    LUNASEC_BACKEND_URL: string;
+  }
+}
+
+// @eslint-disable-next-line @typescript-eslint/no-explicit-any
 type CustomMetadata = Record<string, any>;
 export function timeout(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -60,7 +67,7 @@ export class SecureFrame<E extends keyof ClassLookup> {
     [this.secureElement, this.form] = this.insertSecureElement(componentName);
     this.origin = this.getURLSearchParam('origin');
     this.frameNonce = this.getURLSearchParam('n');
-    this.tokenizer = new Tokenizer({ host: window.location.origin, lockToSession: true });
+    this.tokenizer = new Tokenizer({ host: window.LUNASEC_BACKEND_URL || window.location.origin, lockToSession: true });
     this.rpc = new iFrameRPC(this.origin, () => this.tokenizeField());
     this.startRPC();
   }

--- a/js/sdks/packages/secure-frame-iframe/src/uploader-component.tsx
+++ b/js/sdks/packages/secure-frame-iframe/src/uploader-component.tsx
@@ -15,7 +15,7 @@
  *
  */
 import { ComponentNames } from '@lunasec/react-sdk';
-import { MetaData, Tokenizer } from '@lunasec/tokenizer-sdk';
+import { MetaData } from '@lunasec/tokenizer-sdk';
 import React from 'react';
 import Dropzone, { DropzoneProps, FileWithPath } from 'react-dropzone';
 
@@ -72,9 +72,8 @@ export default class Uploader extends React.Component<UploaderProps, UploaderSta
   }
 
   loadExistingFiles(): void {
-    const tokenizer = new Tokenizer();
     this.fileTokens.map(async (token) => {
-      const metaRes = await tokenizer.getMetadata(token);
+      const metaRes = await this.props.secureframe.tokenizer.getMetadata(token);
       if (!metaRes.success) {
         // If it failed then do nothing and don't show a file
         this.props.secureframe.sendErrorMessage(metaRes.error);
@@ -128,8 +127,7 @@ export default class Uploader extends React.Component<UploaderProps, UploaderSta
           },
           customFields: this.props.secureframe.customMetadata,
         };
-        const tokenizer = new Tokenizer();
-        const uploadRes = await tokenizer.tokenize(buf, meta);
+        const uploadRes = await this.props.secureframe.tokenizer.tokenize(buf, meta);
         if (!uploadRes.success) {
           throw uploadRes.error; // caught below along with any other unforseen issues
         }

--- a/js/sdks/packages/secure-frame-iframe/tsconfig.json
+++ b/js/sdks/packages/secure-frame-iframe/tsconfig.json
@@ -21,6 +21,7 @@
   "include": [
     "src/**/*.ts",
     "src/**/*.tsx",
+    "src/**/*.d.ts"
   ],
   "references": [
     { "path": "../browser-common" },


### PR DESCRIPTION
Backend URL is configurable in iframe by templating a global into the HTML