### PR TITLE
Add Path to S3 Path in Docs CI

### DIFF
--- a/.github/copy-docs-to-s3.sh
+++ b/.github/copy-docs-to-s3.sh
@@ -29,6 +29,12 @@ if [ -z "$AWS_S3_BUCKET" ]; then
   exit 1
 fi
 
+
+if [ -z "$AWS_S3_BUCKET_PATH" ]; then
+  echo "AWS_S3_BUCKET_PATH is not set. Quitting."
+  exit 1
+fi
+
 if [ -z "$AWS_ACCESS_KEY_ID" ]; then
   echo "AWS_ACCESS_KEY_ID is not set. Quitting."
   exit 1
@@ -58,13 +64,13 @@ aws_access_key_id = ${AWS_ACCESS_KEY_ID}
 aws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}" > ~/.aws/credentials
 
 echo "Copying to AWS S3"
-aws s3 sync ${LOCAL_FILES_TO_COPY} s3://${AWS_S3_BUCKET} --exact-timestamps --delete --acl public-read --region ${AWS_DEFAULT_REGION} $*
+aws s3 sync ${LOCAL_FILES_TO_COPY} s3://${AWS_S3_BUCKET}/${AWS_S3_BUCKET_PATH} --exact-timestamps --delete --acl public-read --region ${AWS_DEFAULT_REGION} $*
 
 # This is necessary to ensure that the 404 page works properly because of weird S3 behavior.
 # If this is missing, the 404 page will attempt to point to broken assets because of mismatched hashes in the URL.
 # It would be nice if we could point to `/docs/index.html` and have S3 return that file during 404, but for some reason
 # the S3 console throws an error when we point it at that file... So we have to point it to the root `index.html`.
-aws s3 cp s3://${AWS_S3_BUCKET}/docs/index.html s3://${AWS_S3_BUCKET}/index.html --acl public-read --region ${AWS_DEFAULT_REGION}
+aws s3 cp s3://${AWS_S3_BUCKET}/${AWS_S3_BUCKET_PATH}/index.html s3://${AWS_S3_BUCKET}/index.html --acl public-read --region ${AWS_DEFAULT_REGION}
 
 echo "Invalidation CloudFront cache"
 aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_DISTRIBUTION} --paths "/docs/*"

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -27,7 +27,8 @@ jobs:
     env:
       LOCAL_FILES_TO_COPY: ./build/
       AWS_DEFAULT_REGION: us-east-1
-      AWS_S3_BUCKET: lunasec-docs/docs
+      AWS_S3_BUCKET: lunasec-docs
+      AWS_S3_BUCKET_PATH: docs
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
     steps:


### PR DESCRIPTION
This PR fixes a bug introduced in #162 that broke the docs publishing job.

We can't copy from `/docs/docs/index.html` to `/docs/index.html`. We need to copy from `/docs/index.html` to `/index.html`. In order to do that, we have to know the actual name of the S3 bucket, which is why the values are split now.