### PR TITLE
Change hash used for Skywalking Eyes commit

### DIFF
--- a/tools/license-checker/install-skywalking-eyes.sh
+++ b/tools/license-checker/install-skywalking-eyes.sh
@@ -13,7 +13,7 @@ git clone https://github.com/freeqaz/skywalking-eyes --depth 1
 cd skywalking-eyes
 
 echo "Checking out specific release..."
-git checkout 2654cdd
+git checkout 5d4d5bc
 
 # TODO: Make this work on multiple platforms. For now, run `make build` to build for all OSes.
 # You can then invoke on Mac, for example, the binary at `./skywalking-eyes/bin/darwin/license-eye`


### PR DESCRIPTION
A change that I forgot to commit. This will fail without this change because the Git Clone is only shallow.