### PR TITLE
Remove Docker Login from CI job

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -78,18 +78,6 @@ jobs:
       if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled != 'false' }}
       timeout-minutes: 15
 
-    - name: Login to Docker Hub
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-#    - uses: whoan/docker-build-with-cache-action@v5
-#      with:
-#        username: ${{ secrets.DOCKERHUB_USERNAME }}
-#        password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-#        compose_file: docker-compose.yaml > docker-compose.ci.yaml
-#
 #    - uses: actions/setup-go@v2
 #      with:
 #        go-version: '^1.17.1'


### PR DESCRIPTION
This fix the failure in PR #196 because the author isn't a part of this organization.