### PR TITLE
Fix SEO URL on Mobile Safari

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -40,7 +40,7 @@ const quotedGithubUrl = `"${githubUrl}"`
 module.exports = {
   title: 'LunaSec',
   tagline: 'Data security from the start.',
-  url: 'https://www.lunasec.io/',
+  url: 'https://www.lunasec.io',
   baseUrl: '/docs/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
This currently prevents the "share" button in our docs from working properly. The URL comes out as `https://www.lunasec.io//docs` and it breaks.