### PR TITLE
Remove extraneous Docusaurus dep

### DIFF
--- a/js/sdks/packages/isomorphic-common/package.json
+++ b/js/sdks/packages/isomorphic-common/package.json
@@ -16,6 +16,5 @@
     "typescript": "^4.2.0"
   },
   "dependencies": {
-    "@docusaurus/theme-search-algolia": "^2.0.0-beta.6"
   }
 }


### PR DESCRIPTION
I'm uncertain about why this was here, but it was causing my `npm install` to fail!