### PR TITLE
Fix the schema of the Metrics Server Backend to work with Athena

### DIFF
--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/js/internal-infrastructure/metrics-server-backend/README.md
+++ b/js/internal-infrastructure/metrics-server-backend/README.md
@@ -16,3 +16,49 @@ This is the backend application server to receive analytics metricsConfig from a
 
 The only purpose of this server is to receive metricsConfig and store them in the database. Metrics are used by the LunaSec
 development team to track adoption, feature usage, and to generally understand the community of users better.
+
+## Athena Queries
+This isn't a part of the CDK because the Athena CDK SDK is... Raw CloudFormation.
+I could use Glue Data Catalogue but eh, this is good enough!
+
+### Creating Table
+You have to run this before you can run any queries against Athena. It just tells Athena how to work
+with the JSON data stored in S3.
+
+```sql
+CREATE EXTERNAL TABLE IF NOT EXISTS lunasec_usage_metrics (
+  `version` STRING,
+  stack_id STRING,
+  metrics struct<`tokenizeSuccess`:INTEGER,
+              tokenizeFailure:INTEGER,
+              detokenizeSuccess:INTEGER,
+              detokenizeFailure:INTEGER,
+              createGrantSuccess:INTEGER,
+              createGrantFailure:INTEGER
+              >,
+  clientIP STRING
+)
+PARTITIONED BY (year string, month string, day string, hour string)
+ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
+WITH SERDEPROPERTIES ( 'ignore.malformed.json' = 'true')
+LOCATION 's3://<S3_METRICS_BUCKET>/metrics/';
+```
+
+### Adding Partitions
+You have to scan for partitions before you can run queries. Otherwise, you will see only old data
+or you will see nothing (if you never ran it).
+```sql
+MSCK REPAIR TABLE lunasec_usage_metrics;
+```
+
+### Querying
+Now you can run queries as you would expect to in normal SQL :)
+
+```sql
+SELECT * FROM lunasec_usage_metrics;
+```
+
+If you want to see what file something came from, you can grab it like this:
+```sql
+SELECT "$PATH", * FROM "lunasec_usage_metrics";
+```

--- a/js/internal-infrastructure/metrics-server-backend/lib/deploy-apigateway-to-firehose.ts
+++ b/js/internal-infrastructure/metrics-server-backend/lib/deploy-apigateway-to-firehose.ts
@@ -46,7 +46,7 @@ export class MetricsLambdaBackendStack extends cdk.Stack {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     const s3Destination = new destinations.S3Bucket(bucket, {
-      compression: Compression.SNAPPY,
+      compression: Compression.GZIP,
       dataOutputPrefix:
         'metrics/year=!{timestamp:yyyy}/month=!{timestamp:MM}/day=!{timestamp:dd}/hour=!{timestamp:HH}/rand=!{firehose:random-string}',
       errorOutputPrefix:
@@ -125,12 +125,15 @@ export class MetricsLambdaBackendStack extends cdk.Stack {
   #foreach($key in $inputRoot.keySet())
   ""$key"": $input.json($key),
   #end
-  ""clientIP"": ""$context.identity.sourceIp"",
+  ""clientIP"": ""$context.identity.sourceIp""
 }")
+#set($newLineRegex = '\n')
+#set($formattedJson = "$data.replaceAll($newLineRegex, '')
+")
 {
   "DeliveryStreamName": "${streamName}",
   "Record": {
-    "Data": "$util.base64Encode($data)"
+    "Data": "$util.base64Encode($formattedJson)"
   }
 }`;
   }


### PR DESCRIPTION
This fixes the bad JSON that was getting shoved in the Metrics S3 bucket. I only realized it when I tried to query the data with Athena.

I was using Snappy before and I swapped to GZIP because... I really hate Snappy as a format. It took me over an hour just to be able to decompress the Snappy file that Firehose wrote to S3. That's the reason this bug existed in the first place -- I ran out of time last time trying to test that the Snappy file contents was valid!

Anyway, if you ever need to decompress a Snappy file from S3 in the future, I would recommend the utility `snzip` from [here](https://github.com/kubo/snzip).

The other change that I made was to the schema of the JSON that is inserted into Kinesis Firehose. Previously, the output JSON looked like this:
```json
{
    "version": "1.0.0",
    "stack_id": "1234-1234-1234",
    "metrics": {"tokenizeSuccess":0,"tokenizeFailure":0,"detokenizeSuccess":0,"detokenizeFailure":0,"createGrantSuccess":0,"createGrantFailure":0},
    "clientIP": "123.123.123.123",
}{
    "version": "1.0.0",
    "stack_id": "1234-1234-1234",
    "metrics": {"tokenizeSuccess":0,"tokenizeFailure":0,"detokenizeSuccess":0,"detokenizeFailure":0,"createGrantSuccess":0,"createGrantFailure":0},
    "clientIP": "123.123.123.123",
}{
    "version": "1.0.0",
    "stack_id": "1234-1234-1234",
    "metrics": {"tokenizeSuccess":0,"tokenizeFailure":0,"detokenizeSuccess":0,"detokenizeFailure":0,"createGrantSuccess":0,"createGrantFailure":0},
    "clientIP": "123.123.123.123",
}
```

This is problematic because you can't query data with newlines from AWS Athena. The JSON has to be all on one line. In addition, there was an extra comma after `clientIP` that was also broken. It was super busted.

So I fixed it in the API Gateway request template. That took a while to identify the correct incantation that would give me what I needed. The data written to S3 now looks like this:
```json
{    "version": "1.0.0",    "stack_id": "1234-1234-1234",    "metrics": {"tokenizeSuccess":0,"tokenizeFailure":0,"detokenizeSuccess":0,"detokenizeFailure":0,"createGrantSuccess":0,"createGrantFailure":0},    "clientIP": "123.123.123.123"}
{    "version": "1.0.0",    "stack_id": "1234-1234-1234",    "metrics": {"tokenizeSuccess":0,"tokenizeFailure":0,"detokenizeSuccess":0,"detokenizeFailure":0,"createGrantSuccess":0,"createGrantFailure":0},    "clientIP": "123.123.123.123"}
```

This was a huge pain in the butt, but it all works now. Here is the Athena query that I ended up settling on for creating the table:
```sql
CREATE EXTERNAL TABLE IF NOT EXISTS lunasec_usage_metrics (
  `version` STRING,
  stack_id STRING,
  metrics struct<`tokenizeSuccess`:INTEGER,
              tokenizeFailure:INTEGER,
              detokenizeSuccess:INTEGER,
              detokenizeFailure:INTEGER,
              createGrantSuccess:INTEGER,
              createGrantFailure:INTEGER
              >,
  clientIP STRING
)
PARTITIONED BY (year string, month string, day string, hour string)
ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
WITH SERDEPROPERTIES ( 'ignore.malformed.json' = 'true')
LOCATION 's3://<S3_METRICS_BUCKET>/metrics/';
```