### PR TITLE
Add analytics to every page

### DIFF
--- a/docs/analytics/analytics-inserter.sh
+++ b/docs/analytics/analytics-inserter.sh
@@ -1,1 +1,1 @@
-sed -i '/^<\/body>/e cat ./analytics/analytics-fragment.txt' ./build/index.html
+find ./build -iname "*.html" | xargs -I % sed -i '/^<\/body>/e cat ./analytics/analytics-fragment.txt' %


### PR DESCRIPTION
We were previously only adding it to the root page. Unfortunately, that means we weren't collecting analytics for any other pages in our docs (only for 404s). This fixes that by adding the analytics fragment to every generated `.html` file before it's put in S3.