### PR TITLE
Add the Public Demo config to the CLI

### DIFF
--- a/go/config/tokenizerbackend/dev.yaml
+++ b/go/config/tokenizerbackend/dev.yaml
@@ -1,6 +1,6 @@
 secure_frame_controller:
   cdn_config:
-    protocol: http
+    protocol: ${CDN_PROTOCOL:http}
     host: ${CDN_HOST}
     main_script: js/main-dev.js
     main_style: main.css

--- a/go/scripts/start-tokenizerbackend-dependencies.sh
+++ b/go/scripts/start-tokenizerbackend-dependencies.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 sudo rm -f ./outputs/aws_resources.json
 
-yarn run lunasec start --local-build --env local-dependencies
+npx lunasec start --local-build=true --env=local-dependencies
 r=$?
 if [ $r -ne 0 ]; then
     echo "Unable to bring up local dependencies for the tokenizer"

--- a/go/scripts/wait-for-file.sh
+++ b/go/scripts/wait-for-file.sh
@@ -10,7 +10,7 @@ cmd="$@"
 until test -e "$waitFile"
 do
   >&2 echo "Waiting for file [$waitFile]."
-  sleep 1
+  sleep 5
 done
 
 >&2 echo "Found file [$waitFile]."

--- a/js/demo-apps/packages/demo-back-end/src/dedicated-tokenizer/passport-express/config/configure-lunasec.ts
+++ b/js/demo-apps/packages/demo-back-end/src/dedicated-tokenizer/passport-express/config/configure-lunasec.ts
@@ -22,7 +22,7 @@ if (!process.env.TOKENIZER_URL) {
   throw new Error('Secure frame url env var is not set');
 }
 
-const redirectToLocalhost = process.env.LUNASEC_STACK_ENV === 'demo';
+const publicTokenizerUrl = process.env.REACT_APP_TOKENIZER_URL;
 
 export const lunaSec = new LunaSec({
   tokenizerURL: process.env.TOKENIZER_URL,
@@ -34,6 +34,6 @@ export const lunaSec = new LunaSec({
     // or null if a user is not logged in.  LunaSec uses this to automatically create and verify token grants
     // and to bootstrap a session if you are using the express-auth-plugin
     sessionIdProvider: lunaSecSessionIdProvider,
-    redirectToLocalhost,
+    publicTokenizerUrl,
   },
 });

--- a/js/demo-apps/packages/demo-back-end/src/dedicated-tokenizer/passport-graphql/config/configure-lunasec.ts
+++ b/js/demo-apps/packages/demo-back-end/src/dedicated-tokenizer/passport-graphql/config/configure-lunasec.ts
@@ -22,7 +22,7 @@ if (!process.env.TOKENIZER_URL) {
   throw new Error('Secure frame url env var is not set');
 }
 
-const redirectToLocalhost = process.env.LUNASEC_STACK_ENV === 'demo';
+const publicTokenizerUrl = process.env.REACT_APP_TOKENIZER_URL;
 
 export const lunaSec = new LunaSec({
   tokenizerURL: process.env.TOKENIZER_URL,
@@ -33,6 +33,6 @@ export const lunaSec = new LunaSec({
     // Provide a small middleware(ours is called lunaSecSessionIdProvider) that takes in the req object and returns a promise containing a session token
     // or null if a user is not logged in.  LunaSec uses this to automatically create and verify token grants
     sessionIdProvider: readSessionFromRequest,
-    redirectToLocalhost,
+    publicTokenizerUrl,
   },
 });

--- a/js/demo-apps/packages/demo-back-end/src/simple-tokenizer/config/configure-lunasec.ts
+++ b/js/demo-apps/packages/demo-back-end/src/simple-tokenizer/config/configure-lunasec.ts
@@ -23,5 +23,5 @@ export const simpleTokenizerBackend = new SimpleTokenizerBackend({
   s3Bucket: process.env.CIPHERTEXT_S3_BUCKET || 'You must set a bucket...',
   awsCredentials: { accessKeyId: 'test', secretAccessKey: 'test' },
   useLocalStack: true,
-  redirectToLocalhost: redirectToLocalhost,
+  redirectToLocalhost,
 });

--- a/js/internal-infrastructure/public-live-demo/demo-nginx.conf
+++ b/js/internal-infrastructure/public-live-demo/demo-nginx.conf
@@ -92,11 +92,13 @@ server {
   set $external_demo_s3_endpoint mocked-aws-s3.lunasec.dev;
   server_name mocked-aws-s3.lunasec.dev;
 
-  set $upstream_app_endpoint http://localstack-proxy:4568;
+  set $upstream_app_endpoint http://localstack:4566;
   location /  {
     proxy_set_header Origin $upstream_app_endpoint;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_pass $upstream_app_endpoint;
+    proxy_hide_header 'access-control-allow-origin';
+    add_header 'access-control-allow-origin' 'https://tokenizer.lunasec.dev';
     proxy_cookie_domain localhost $external_demo_s3_endpoint;
     proxy_redirect $upstream_app_endpoint/ https://$external_demo_s3_endpoint/;
   }
@@ -112,6 +114,10 @@ server {
     proxy_set_header Origin $upstream_app_endpoint;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_pass $upstream_app_endpoint;
+    proxy_hide_header 'access-control-allow-credentials';
+    proxy_hide_header 'access-control-allow-origin';
+    add_header 'access-control-allow-credentials' 'true';
+    add_header 'access-control-allow-origin' 'https://app.lunasec.dev';
     proxy_cookie_domain localhost $external_demo_tokenizer_endpoint;
     proxy_redirect $upstream_app_endpoint/ https://$external_demo_tokenizer_endpoint/;
   }

--- a/js/internal-infrastructure/public-live-demo/demo-nginx.conf
+++ b/js/internal-infrastructure/public-live-demo/demo-nginx.conf
@@ -1,0 +1,119 @@
+resolver 127.0.0.11 ipv6=off;
+
+server {
+  listen 80;
+  server_name lunasec.dev;
+  return 302 https://app.lunasec.dev$request_uri;
+}
+
+server {
+  listen 80;
+  set $external_demo_app_endpoint app.lunasec.dev;
+  server_name app.lunasec.dev;
+
+  set $upstream_app_endpoint http://application-front-end:3000;
+  location /  {
+    proxy_set_header Origin $upstream_app_endpoint;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_pass $upstream_app_endpoint;
+    proxy_cookie_domain localhost $external_demo_app_endpoint;
+    proxy_redirect $upstream_app_endpoint/ https://$external_demo_app_endpoint/;
+  }
+}
+
+server {
+  listen 80;
+  set $external_demo_express_endpoint express.lunasec.dev;
+  server_name express.lunasec.dev;
+
+  set $upstream_app_endpoint http://application-back-end:3001;
+  location /  {
+    proxy_set_header Origin $upstream_app_endpoint;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_pass $upstream_app_endpoint;
+    proxy_hide_header 'access-control-allow-origin';
+    add_header 'access-control-allow-origin' 'https://app.lunasec.dev';
+    proxy_cookie_domain localhost $external_demo_express_endpoint;
+    proxy_redirect $upstream_app_endpoint/ https://$external_demo_express_endpoint/;
+  }
+}
+
+server {
+  listen 80;
+  set $external_demo_graphql_endpoint graphql.lunasec.dev;
+  server_name graphql.lunasec.dev;
+
+  set $upstream_app_endpoint http://application-back-end:3002;
+  location /  {
+    proxy_set_header Origin $upstream_app_endpoint;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_pass $upstream_app_endpoint;
+    proxy_hide_header 'access-control-allow-origin';
+    add_header 'access-control-allow-origin' 'https://app.lunasec.dev';
+    proxy_cookie_domain localhost $external_demo_graphql_endpoint;
+    proxy_redirect $upstream_app_endpoint/ https://$external_demo_graphql_endpoint/;
+  }
+}
+
+server {
+  listen 80;
+  set $external_demo_simple_endpoint simple.lunasec.dev;
+  server_name simple.lunasec.dev;
+
+  set $upstream_app_endpoint http://application-back-end:3003;
+  location /  {
+    proxy_set_header Origin $upstream_app_endpoint;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_pass $upstream_app_endpoint;
+    proxy_hide_header 'access-control-allow-origin';
+    add_header 'access-control-allow-origin' 'https://app.lunasec.dev';
+    proxy_cookie_domain localhost $external_demo_simple_endpoint;
+    proxy_redirect $upstream_app_endpoint/ https://$external_demo_simple_endpoint/;
+  }
+}
+
+server {
+  listen 80;
+  set $external_demo_secure_frame_endpoint secure-frame.lunasec.dev;
+  server_name secure-frame.lunasec.dev;
+
+  set $upstream_app_endpoint http://secure-frame-iframe:8000;
+  location /  {
+    proxy_set_header Origin $upstream_app_endpoint;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_pass $upstream_app_endpoint;
+    proxy_cookie_domain localhost $external_demo_secure_frame_endpoint;
+    proxy_redirect $upstream_app_endpoint/ https://$external_demo_secure_frame_endpoint/;
+  }
+}
+
+server {
+  listen 80;
+  set $external_demo_s3_endpoint mocked-aws-s3.lunasec.dev;
+  server_name mocked-aws-s3.lunasec.dev;
+
+  set $upstream_app_endpoint http://localstack-proxy:4568;
+  location /  {
+    proxy_set_header Origin $upstream_app_endpoint;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_pass $upstream_app_endpoint;
+    proxy_cookie_domain localhost $external_demo_s3_endpoint;
+    proxy_redirect $upstream_app_endpoint/ https://$external_demo_s3_endpoint/;
+  }
+}
+
+server {
+  listen 80;
+  set $external_demo_tokenizer_endpoint tokenizer.lunasec.dev;
+  server_name tokenizer.lunasec.dev;
+
+  set $upstream_app_endpoint http://tokenizer-backend:37766;
+  location /  {
+    proxy_set_header Origin $upstream_app_endpoint;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_pass $upstream_app_endpoint;
+    proxy_cookie_domain localhost $external_demo_tokenizer_endpoint;
+    proxy_redirect $upstream_app_endpoint/ https://$external_demo_tokenizer_endpoint/;
+  }
+}
+

--- a/js/sdks/packages/cli/src/config/types.ts
+++ b/js/sdks/packages/cli/src/config/types.ts
@@ -122,6 +122,11 @@ export const testsConfigOptionsDefaults: DevelopmentConfigOptions = {
   tokenizerUrl: 'http://tokenizer-backend:37766',
 };
 
+export const hostedLiveDemoConfigOptionsDefaults: DevelopmentConfigOptions = {
+  ...devConfigOptionsDefaults,
+  tokenizerUrl: 'https://tokenizer.lunasec.dev',
+};
+
 export type LunaSecServices = 'tokenizer-backend' | 'secure-frame-frontend' | 'analytics-collector';
 
 export type ServiceVersions = Record<LunaSecServices, string>;

--- a/js/sdks/packages/cli/src/constants/cli.ts
+++ b/js/sdks/packages/cli/src/constants/cli.ts
@@ -15,3 +15,5 @@
  *
  */
 export const lunaSecDir = '.lunasec';
+
+export const awsResourcesOutputFile = 'aws_resources.json';

--- a/js/sdks/packages/cli/src/docker-compose/generate-nginx-config.ts
+++ b/js/sdks/packages/cli/src/docker-compose/generate-nginx-config.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 by LunaSec (owned by Refinery Labs, Inc)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { LunaSecStackEnvironment } from './lunasec-stack';
+
+export function generateNginxEnvConfig(
+  env: LunaSecStackEnvironment,
+  baseEnvConfig: Record<string, string>
+): Record<string, string> {
+  if (env !== 'hosted-live-demo') {
+    return baseEnvConfig;
+  }
+
+  return {
+    ...baseEnvConfig,
+    APPLICATION_FRONT_END: 'https://app.lunasec.dev',
+    CDN_HOST: 'secure-frame.lunasec.dev',
+    LOCALSTACK_URL: 'http://localhost:4566',
+    // TODO (freeqaz) I'm not sure what this value needs to be still.
+    // LOCAL_HTTPS_PROXY: '', // 'https://localstack-proxy:4568',
+    // LOCALSTACK_HOSTNAME: 'localstack.lunasec.dev',
+    REACT_APP_EXPRESS_URL: 'https://express.lunasec.dev',
+    REACT_APP_GRAPHQL_URL: 'https://graphql.lunasec.dev',
+    REACT_APP_TOKENIZER_URL: 'https://tokenizer.lunasec.dev',
+    // TODO Actually make this use the tests config
+    SESSION_JWKS_URL: 'http://application-back-end:3001/.lunasec/jwks.json',
+  };
+}

--- a/js/sdks/packages/cli/src/docker-compose/generate-nginx-config.ts
+++ b/js/sdks/packages/cli/src/docker-compose/generate-nginx-config.ts
@@ -27,8 +27,9 @@ export function generateNginxEnvConfig(
   return {
     ...baseEnvConfig,
     APPLICATION_FRONT_END: 'https://app.lunasec.dev',
+    CDN_PROTOCOL: 'https',
     CDN_HOST: 'secure-frame.lunasec.dev',
-    LOCALSTACK_URL: 'http://localhost:4566',
+    LOCALSTACK_URL: 'https://mocked-aws-s3.lunasec.dev',
     // TODO (freeqaz) I'm not sure what this value needs to be still.
     // LOCAL_HTTPS_PROXY: '', // 'https://localstack-proxy:4568',
     // LOCALSTACK_HOSTNAME: 'localstack.lunasec.dev',

--- a/js/sdks/packages/cli/src/docker-compose/lunasec-stack.ts
+++ b/js/sdks/packages/cli/src/docker-compose/lunasec-stack.ts
@@ -494,17 +494,17 @@ export class LunaSecStackDockerCompose {
     if (this.env === 'demo') {
       return 'localhost';
     }
-    if (this.env === 'tests' || this.env === 'hosted-live-demo') {
+    if (this.env === 'tests') {
       return 'application-back-end';
     }
     return undefined;
   }
 
   getLocalstackHostname() {
-    if (this.env === 'tests' || this.env === 'hosted-live-demo') {
-      return 'localstack';
+    if (this.env === 'demo') {
+      return 'localhost';
     }
-    return 'localhost';
+    return 'localstack';
   }
 
   getSecureFrameHostname() {
@@ -515,6 +515,16 @@ export class LunaSecStackDockerCompose {
   }
 
   getAuthenticationProviders(): Record<string, AuthProviderConfig> | undefined {
+    if (this.env === 'hosted-live-demo') {
+      return {
+        'express-back-end': {
+          url: `http://express.lunasec.dev`,
+        },
+        'graphql-back-end': {
+          url: `http://graphql.lunasec.dev`,
+        },
+      };
+    }
     const authProviderHostname = this.getBackEndHostname();
     if (authProviderHostname !== undefined) {
       return {

--- a/js/sdks/packages/cli/src/docker-compose/lunasec-stack.ts
+++ b/js/sdks/packages/cli/src/docker-compose/lunasec-stack.ts
@@ -523,10 +523,10 @@ export class LunaSecStackDockerCompose {
     if (this.env === 'hosted-live-demo') {
       return {
         'express-back-end': {
-          url: `http://express.lunasec.dev`,
+          url: `https://express.lunasec.dev`,
         },
         'graphql-back-end': {
-          url: `http://graphql.lunasec.dev`,
+          url: `https://graphql.lunasec.dev`,
         },
       };
     }
@@ -547,9 +547,9 @@ export class LunaSecStackDockerCompose {
   getApplicationBackEndEnvUrls() {
     if (this.env === 'hosted-live-demo') {
       return {
-        REACT_APP_EXPRESS_URL: `http://express.lunasec.dev`,
-        REACT_APP_GRAPHQL_URL: `http://graphql.lunasec.dev`,
-        REACT_APP_SIMPLE_TOKENIZER_URL: `http://simple.lunasec.dev`,
+        REACT_APP_EXPRESS_URL: `https://express.lunasec.dev`,
+        REACT_APP_GRAPHQL_URL: `https://graphql.lunasec.dev`,
+        REACT_APP_SIMPLE_TOKENIZER_URL: `https://simple.lunasec.dev`,
       };
     }
 

--- a/js/sdks/packages/cli/src/docker-compose/lunasec-stack.ts
+++ b/js/sdks/packages/cli/src/docker-compose/lunasec-stack.ts
@@ -27,6 +27,7 @@ import {
   LunaSecStackConfigOptions,
   testsConfigOptionsDefaults,
 } from '../config/types';
+import { awsResourcesOutputFile } from '../constants/cli';
 import { formatAuthenticationProviders } from '../utils/auth-providers';
 
 import { ComposeSpecification, DefinitionsService } from './docker-compose-types';
@@ -354,7 +355,7 @@ export class LunaSecStackDockerCompose {
       config: {
         ...this.baseServiceConfig(name),
         ...(this.localBuild ? localBuildConfig : dockerBuildConfig),
-        command: 'deploy --local --output /outputs/aws_resources.json',
+        command: `deploy --local --output /outputs/${awsResourcesOutputFile}`,
         depends_on: [this.localstackProxy().name],
       },
     };

--- a/js/sdks/packages/cli/src/docker-compose/lunasec-stack.ts
+++ b/js/sdks/packages/cli/src/docker-compose/lunasec-stack.ts
@@ -23,6 +23,7 @@ import {
   AuthProviderConfig,
   devConfigOptionsDefaults,
   DevelopmentConfigOptions,
+  hostedLiveDemoConfigOptionsDefaults,
   LunaSecStackConfigOptions,
   testsConfigOptionsDefaults,
 } from '../config/types';
@@ -97,6 +98,9 @@ const localstackImage = 'localstack/localstack:0.12.19';
 function getStackConfigOptions(env: LunaSecStackEnvironment, configOptions?: DevelopmentConfigOptions) {
   if (env === 'tests') {
     return testsConfigOptionsDefaults;
+  }
+  if (env === 'hosted-live-demo') {
+    return hostedLiveDemoConfigOptionsDefaults;
   }
   return {
     ...devConfigOptionsDefaults,
@@ -501,10 +505,10 @@ export class LunaSecStackDockerCompose {
   }
 
   getLocalstackHostname() {
-    if (this.env === 'demo') {
-      return 'localhost';
+    if (this.env === 'tests' || this.env === 'hosted-live-demo') {
+      return 'localstack';
     }
-    return 'localstack';
+    return 'localhost';
   }
 
   getSecureFrameHostname() {
@@ -567,7 +571,7 @@ export class LunaSecStackDockerCompose {
 
     const localstackUrl = `http://${this.getLocalstackHostname()}:4566`;
     const localstackHttpsProxyUrl = 'https://localstack-proxy:4568';
-    const tokenizerHost = 'tokenizer-backend:37766';
+    const tokenizerHost = 'http://tokenizer-backend:37766';
     const cdnHost = `${this.getSecureFrameHostname()}:8000`;
 
     // These values are for the hosts that the Integration Test depends on in
@@ -594,7 +598,7 @@ export class LunaSecStackDockerCompose {
 
       STAGE: 'DEV',
       LUNASEC_STACK_ENV: this.env,
-      TOKENIZER_URL: `http://${tokenizerHost}`,
+      TOKENIZER_URL: tokenizerHost,
       REACT_APP_TOKENIZER_URL: this.stackConfigOptions.tokenizerUrl,
       CDN_HOST: cdnHost,
       LOCALSTACK_URL: localstackUrl,

--- a/js/sdks/packages/cli/src/docker-compose/lunasec-stack.ts
+++ b/js/sdks/packages/cli/src/docker-compose/lunasec-stack.ts
@@ -540,6 +540,14 @@ export class LunaSecStackDockerCompose {
   }
 
   getApplicationBackEndEnvUrls() {
+    if (this.env === 'hosted-live-demo') {
+      return {
+        REACT_APP_EXPRESS_URL: `http://express.lunasec.dev`,
+        REACT_APP_GRAPHQL_URL: `http://graphql.lunasec.dev`,
+        REACT_APP_SIMPLE_TOKENIZER_URL: `http://simple.lunasec.dev`,
+      };
+    }
+
     const backEndHostname = this.getBackEndHostname();
     if (backEndHostname !== undefined) {
       return {

--- a/js/sdks/packages/node-sdk/src/express-auth-plugin/index.ts
+++ b/js/sdks/packages/node-sdk/src/express-auth-plugin/index.ts
@@ -37,14 +37,14 @@ export interface ExpressAuthPluginConfig {
   auth: KeyService;
   // TODO: (forrest) remove, I'm 99% sure you can do this by just calling `register` on an express router instead of the base app
   pluginBaseUrl?: string;
-  redirectToLocalhost: boolean;
+  publicTokenizerUrl?: string;
 }
 
 export class ExpressAuthPlugin {
   private readonly tokenizerUrl: string;
   private readonly auth: KeyService;
   private readonly config: ExpressAuthPluginConfig;
-  private readonly redirectToLocalhost: boolean;
+  private readonly publicTokenizerUrl?: string;
 
   /**
    * @ignore
@@ -53,7 +53,7 @@ export class ExpressAuthPlugin {
     this.auth = config.auth;
     this.config = config;
     this.tokenizerUrl = config.tokenizerURL;
-    this.redirectToLocalhost = config.redirectToLocalhost;
+    this.publicTokenizerUrl = config.publicTokenizerUrl;
   }
 
   // private filterClaims<T extends JWTPayload>(payload: T): Partial<T> {
@@ -72,10 +72,8 @@ export class ExpressAuthPlugin {
   // }
 
   private getTokenizerAuthUrl() {
-    if (this.redirectToLocalhost) {
-      const url = new URL(this.tokenizerUrl);
-      url.hostname = 'localhost';
-      return url.toString();
+    if (this.publicTokenizerUrl) {
+      return this.publicTokenizerUrl;
     }
     return this.tokenizerUrl;
   }

--- a/js/sdks/packages/node-sdk/src/main/index.ts
+++ b/js/sdks/packages/node-sdk/src/main/index.ts
@@ -61,7 +61,7 @@ export interface LunaSecConfig {
     /** A callback used automatically by LunaSec when we have the req object and would like to know the sessionId.  Used in automatic granting and also the Auth Plugin */
     sessionIdProvider: SessionIdProvider;
     /** Optionally have the auth redirect URL use localhost as the domain name. This is used in the demo mode and local development. */
-    redirectToLocalhost: boolean;
+    publicTokenizerUrl?: string;
   };
   /** Optionally configure the Secure Resolver functionality of the plugin, must be configured if you want to use Secure Resolvers */
   secureResolverConfig?: SecureResolverSdkConfig;
@@ -92,7 +92,7 @@ export class LunaSec {
       // payloadClaims: config.auth.payloadClaims,
       tokenizerURL: config.tokenizerURL,
       pluginBaseUrl: config.auth.pluginBaseUrl,
-      redirectToLocalhost: config.auth.redirectToLocalhost,
+      publicTokenizerUrl: config.auth.publicTokenizerUrl,
     });
 
     this.grants = new Grants(this.keyService, config.tokenizerURL, config.auth.sessionIdProvider);


### PR DESCRIPTION
There is still a bunch that's broken with this, but I'll walk you through it more tomorrow.

Basically:
- I'm using `docker context` via SSH to deploy the service using `docker-compose` directly.
- It's kind of jank. Paths have to be the same between your box and the Docker host, but that's doable.
- Volumes are passed currently in the `docker-config.yaml` file and they need to be removed for the live demo env.
- This error happens when it loads the secure frame because a host URI is bad still: `Blocked loading mixed active content “http://application-back-end:3001/.lunasec/secure-frame?state=c2af07f4-f6f4-4310-aa0b-ac7e9e92562a”`

I wrote the NGINX config and that seems to work properly. Overall, this seems pretty close now! We just need to sit down and debug the last remaining pieces. :)