### PR TITLE
Add link step after build

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -53,6 +53,7 @@ jobs:
         run: |
           npx lerna bootstrap --ci
           yarn compile:dev:infrastructure
+          npx lerna link
 
       - name: Build Repo
         working-directory: js/sdks


### PR DESCRIPTION
Alright, one more try. I tested this locally. If you don't have the `bin` file built when you do `lerna bootstrap`, it will not add the `node_modules/.bin/s3-redirect-generator` symlink. Fortunately, a `lerna link` fixes the problem after the build runs!