### PR TITLE
log4j download page

### DIFF
--- a/docs/blog/2021-12-09-log4j-zero-day.md
+++ b/docs/blog/2021-12-09-log4j-zero-day.md
@@ -77,7 +77,7 @@ At the time this post was created (December 9th, 2021), no stable release was av
 As of December 10th, 2021, Version 2.15.0 was released. log4j-core.jar is available on Maven Central [here](https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.15.0/), with [[release notes](https://logging.apache.org/log4j/2.x/changes-report.html#a2.15.0)] and 
 [[log4j security announcements](https://logging.apache.org/log4j/2.x/security.html)].
 
-Releases to GitHub appear to still be pending.
+The release can also be downloaded from the Apache Log4j [Download](https://logging.apache.org/log4j/2.x/download.html) page.
 
 ## Temporary Mitigation
 


### PR DESCRIPTION
Apache projects' primary approach to releases is to provide downloads via the apache project web sites - not via github.