### PR TITLE
Fix example to use log4j2

### DIFF
--- a/docs/blog/2021-12-09-log4j-zero-day.md
+++ b/docs/blog/2021-12-09-log4j-zero-day.md
@@ -105,7 +105,8 @@ As per [this discussion on HackerNews](https://news.ycombinator.com/item?id=2950
 ### Example Vulnerable Code
 
 ```ts
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.*;
 import java.sql.SQLException;
@@ -113,7 +114,7 @@ import java.util.*;
 
 public class VulnerableLog4jExampleHandler implements HttpHandler {
 
-  static Logger log = Logger.getLogger(log4jExample.class.getName());
+  static Logger log = LogManager.getLogger(log4jExample.class.getName());
 
   /**
    * A simple HTTP endpoint that reads the request's User Agent and logs it back.

--- a/docs/blog/2021-12-09-log4j-zero-day.md
+++ b/docs/blog/2021-12-09-log4j-zero-day.md
@@ -220,6 +220,7 @@ methods are still prevalent.
 5. Update that 2.15.0 is released.
 6. Added the MS Paint logo[4], and updated example code to be slightly more clear (it's not string concatenation).
 7. Reported on iPhones being affected by the vulnerability, and included local reproduction code + steps.
+8. Updated example code to use Log4j2 syntax.
 
 ### References
 


### PR DESCRIPTION
pedantry: make the example code actually valid log4j 2 use, not log4j 1.x

PR #260 was abandoned because the submitter recognized the example was using log4j 1.x syntax, but if that PR hadn't been abandoned it would have saved me time checking that paramaterized usage was vulnerable and submitting PR #270 to make the same change (and I'm not sure 1.x is vulnerable anyway)