### PR TITLE
Fix bad image links by using MDX syntax instead

### DIFF
--- a/docs/blog/2021-12-12-log4j-zero-day-mitigation-guide.mdx
+++ b/docs/blog/2021-12-12-log4j-zero-day-mitigation-guide.mdx
@@ -238,7 +238,9 @@ Now that you know where you're vulnerable, the following sections will help you 
 This diagram created by the [Swiss Government](https://www.govcert.ch/blog/zero-day-exploit-targeting-popular-java-library-log4j/) is an excellent
 visualization of the Log4Shell exploit.  Take note of the possible solutions (shown in red) as we go over mitigation strategies.  
 
-[![log4shell 0day diagram](https://www.lunasec.io/docs/img/log4j-attack-and-mitigations.png)](https://www.lunasec.io/docs/img/log4j-attack-and-mitigations.png)
+<a href="https://www.lunasec.io/docs/img/log4j-attack-and-mitigations.png" target="_blank" rel="noopener">
+  <img src="https://www.lunasec.io/docs/img/log4j-attack-and-mitigations.png" alt="log4shell 0day diagram" />
+</a>
 
 
 ### Option 1: Upgrading to 2.16.0

--- a/docs/blog/2021-12-14-log4j-zero-day-update-on-CVE-2021-45046.mdx
+++ b/docs/blog/2021-12-14-log4j-zero-day-update-on-CVE-2021-45046.mdx
@@ -153,7 +153,9 @@ _before_ the `LOG4J_FORMAT_MSG_NO_LOOKUPS` mitigation.
 Running this vulnerable server and exploiting the vulnerability with our [log4shell CLI tool](https://github.com/lunasec-io/lunasec/tree/master/tools/log4shell)
 we observed that RCE was still possible in versions `2.10.0 <= Apache log4j < 2.14.1`:
 
-[![Log4j RCE on log4j 2.14.1 with mitigation](https://www.lunasec.io/docs/img/log4shell-CVE-2021-45046-exploitation-with-mitigation.png)](https://www.lunasec.io/docs/img/log4shell-CVE-2021-45046-exploitation-with-mitigation.png)
+<a href="https://www.lunasec.io/docs/img/log4shell-CVE-2021-45046-exploitation-with-mitigation.png" target="_blank" rel="noopener">
+  <img src="https://www.lunasec.io/docs/img/log4shell-CVE-2021-45046-exploitation-with-mitigation.png" alt="Log4j RCE on log4j 2.14.1 with mitigation" />
+</a>
 
 The server is still vulnerable even with `log4j2.noFormatMsgLookup` enabled because the Pattern Layout has been modified
 to include a reference to a Thread Context value. It appears that referencing Thread Context values in this way bypasses
@@ -188,7 +190,9 @@ resolving of `${ctx:apiversion}` which will contain our payload.
 The less impactful part of this CVE, if you have updated your Log4j version to `2.15.0`, is that there is a limited
 denial of service (DOS) possible under certain circumstances. See the below screenshot:
 
-[![Log4j DOS on log4j 2.15.0 with mitigation](https://www.lunasec.io/docs/img/log4shell-CVE-2021-45046-dos-with-mitigation.png)](https://www.lunasec.io/docs/img/log4shell-CVE-2021-45046-dos-with-mitigation.png)
+<a href="https://www.lunasec.io/docs/img/log4shell-CVE-2021-45046-dos-with-mitigation.png" target="_blank" rel="noopener">
+  <img src="https://www.lunasec.io/docs/img/log4shell-CVE-2021-45046-dos-with-mitigation.png" alt="Log4j DOS on log4j 2.15.0 with mitigation" />
+</a>
 
 However, in our testing we did not find this DOS to be resource consuming as it seemed that the infinite loop created by recursively
 resolving `${ctx:apiversion}` was identified by the program and errored out.


### PR DESCRIPTION
This is unfortunately necessary for Docusaurus to be happy. Otherwise, we generate links with a trailing slash and everything breaks >.<