### PR TITLE
Log4Shell: Scan Into Zip Archives

### DIFF
--- a/tools/log4shell/constants/fs.go
+++ b/tools/log4shell/constants/fs.go
@@ -17,5 +17,6 @@ package constants
 const (
 	JarFileExt   = ".jar"
 	WarFileExt   = ".war"
+	ZipFileExt   = ".zip"
 	ClassFileExt = ".class"
 )

--- a/tools/log4shell/scan/scan.go
+++ b/tools/log4shell/scan/scan.go
@@ -113,7 +113,7 @@ func scanFile(path string, file *zip.File, onlyScanArchives bool) (findings []ty
 			findings = []types.Finding{*finding}
 		}
 		return
-	case constants.JarFileExt, constants.WarFileExt:
+	case constants.JarFileExt, constants.WarFileExt, constants.ZipFileExt:
 		if onlyScanArchives {
 			finding := scanArchiveFile(path, file)
 			if finding != nil {
@@ -181,7 +181,7 @@ func SearchDirsForVulnerableClassFiles(searchDirs []string, onlyScanArchives boo
 
 		fileExt := util.FileExt(path)
 		switch fileExt {
-		case constants.JarFileExt, constants.WarFileExt:
+		case constants.JarFileExt, constants.WarFileExt, constants.ZipFileExt:
 			log.Debug().
 				Str("path", path).
 				Msg("scanning archive")


### PR DESCRIPTION
### Context
---
Some of our applications are bundled into `zip` archives for distribution, it is helpful to be able to scan into these archives without needing to locate and `unzip` them by hand prior to executing the `log4shell` tool.


### Changes
---
This pull adds `zip` archives to the supported filetypes, recursively.