### PR TITLE
Added a note on the trustURLCodebase's inreliability.

### DIFF
--- a/docs/blog/2021-12-09-log4j-zero-day.mdx
+++ b/docs/blog/2021-12-09-log4j-zero-day.mdx
@@ -83,6 +83,7 @@ vulnerability in Apple's servers.
 According to [this blog post](https://www.cnblogs.com/yyhuni/p/15088134.html) (see [translation](https://www-cnblogs-com.translate.goog/yyhuni/p/15088134.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en-US)),
 JDK versions greater than `6u211`, `7u201`, `8u191`, and `11.0.1` are not affected by the LDAP attack vector. In these versions
 `com.sun.jndi.ldap.object.trustURLCodebase` is set to `false` meaning JNDI cannot load remote code using LDAP.
+** Edit: ** that might not be the case for certain `DirObjectFactory` implementations - see https://alex-kiselyov.medium.com/why-trusturlcodebase-may-not-save-you-from-log4j2-ldap-vulnerability-cve-2021-44228-f87b3c1eadaf for the detailed description.
 
 However, there are other attack vectors targeting this vulnerability which can result in RCE. An attacker could still leverage
 existing code on the server to execute a payload. An attack targeting the class


### PR DESCRIPTION
A link to an article explaining why setting `com.sun.jndi.ldap.object.trustURLCodebase` to `true` is not 100% reliable added.