### PR TITLE
Fix typo in log statement: fieName -> fileName

### DIFF
--- a/tools/log4shell/analyze/analyze.go
+++ b/tools/log4shell/analyze/analyze.go
@@ -121,7 +121,7 @@ func ProcessArchiveFile(reader io.Reader, filePath, fileName string) (finding *t
 	fileHash, err := util.HexEncodedSha256FromReader(reader)
 	if err != nil {
 		log.Warn().
-			Str("fieName", fileName).
+			Str("fileName", fileName).
 			Str("path", filePath).
 			Err(err).
 			Msg("unable to hash file")


### PR DESCRIPTION
Fix typo in log statement: fieName -> fileName

**STOP**: Is this a **security vulnerability**?  If so, follow Responsible Disclosure and email us at security@lunasec.io 
instead of opening a public PR.
