### PR TITLE
close reader which is left open in log4shell cli

### DIFF
--- a/tools/log4shell/constants/version.go
+++ b/tools/log4shell/constants/version.go
@@ -14,4 +14,4 @@
 //
 package constants
 
-const Version = "1.4.1"
+const Version = "1.4.2"

--- a/tools/log4shell/scan/scan.go
+++ b/tools/log4shell/scan/scan.go
@@ -203,6 +203,8 @@ func (s *Log4jDirectoryScanner) scanArchiveFile(
 			Msg("unable to open class file")
 		return
 	}
+	defer reader.Close()
+
 	return s.processArchiveFile(reader, path, file.Name)
 }
 


### PR DESCRIPTION
Reader is left open while scanning zip files. This could be the source of issue #368 