### PR TITLE
Build log4shell w/out linking to MUSL C library

### DIFF
--- a/tools/log4shell/Dockerfile
+++ b/tools/log4shell/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /build
 COPY . /build
 COPY --from=java-build /build/hotpatch-payload/target/classes/Log4ShellHotpatch.class /build
 
-RUN go build -o log4shell . 
+RUN CGO_ENABLED=0 go build -o log4shell . 
 
 FROM alpine
 


### PR DESCRIPTION
Build log4shell w/ CGO_ENABLED=0 enabled so that the resulting binary isn't linked to Alpine's MUSL C library, resulting in a binary that runs on CentOS.

I won't be able to sign the CDA, so this is another "convene a tiger team and reimplement this change" kind of thing.