### PR TITLE
edited zero-day-mitigation-guide and zero-day-update

### DIFF
--- a/docs/blog/2021-12-12-log4j-zero-day-mitigation-guide.mdx
+++ b/docs/blog/2021-12-12-log4j-zero-day-mitigation-guide.mdx
@@ -26,7 +26,7 @@ authors: [free, chris, forrest]
 
 _Originally Posted @ December 12th & Last Updated @ December 19th, 3:37pm PST_
 
-**Also read: Our analysis of [CVE-2021-45046](https://www.lunasec.io/docs/blog/log4j-zero-day-update-on-cve-2021-45046) (a second log4j vulnerability)**
+**Also read: Our analysis of [CVE-2021-45046](https://www.lunasec.io/docs/blog/log4j-zero-day-update-on-cve-2021-45046) (a second log4j vulnerability).**
 
 A few days ago, a serious new vulnerability was identified in Apache log4j v2 and published as 
 [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-44228). 
@@ -48,29 +48,29 @@ earlier blog post](https://www.lunasec.io/docs/blog/log4j-zero-day/).
 Because of the severe impact from this vulnerability, there has been a lot of discussion on the internet
 about it. **Some of this information is outdated or wrong and _will_ leave you vulnerable if you follow it!**
 
-In contrast, this guide has been written by a team of professional Security Engineers at LunaSec. Everything here has
-been peer-reviewed by multiple security experts, and where possible our sources will be linked for other Security
+By contrast, this guide has been written by a team of professional Security Engineers at LunaSec. Everything here has
+been peer-reviewed by multiple security experts, and where possible our sources will be linked from other Security
 professionals to verify against.  This post links to many other guides and how-tos that we believe are trustworthy.  
 
 The full list of common bad advice is at the [bottom of this post](#known-bad-advice). If you believe you've already 
-mitigated Log4Shell, or you believe you're not vulnerable, please double-check your current information is up-to-date. 
+mitigated Log4Shell, or you believe you're not vulnerable, please double-check that your current information is up-to-date. 
 
 ## Determine if you are impacted by Log4Shell
 
-This vulnerability affects anybody who's using the log4j packages. That means it's
-primarily Java, but other languages like Scala, Groovy, or Clojure are also impacted.
+This vulnerability affects anybody who's using the log4j packages. That means that
+primarily Java, but also other languages like Scala, Groovy, or Clojure, are impacted.
 
 ### Automatically Scanning Your Package
 
 We've built a command line utility that can check `.jar` and `.war` files in your project directory and report if any are vulnerable. 
 It works by scanning for hashes of [known vulnerable log4j classes](https://github.com/mubix/CVE-2021-44228-Log4Shell-Hashes).
-If you have a vulnerable version of a log4j in your built Java project, the hash will match a one
+If you have a vulnerable version of a log4j in your built Java project, the hash will match one
 of the hashes in the list.
 
 **[Download from GitHub](https://github.com/lunasec-io/lunasec/releases/)**
 
 _Make sure you download the right version for your Operating System and CPU architecture._ Once downloaded, you can extract
-it and run the `log4shell` command in your terminal.  The tool can scan individual files or whole directories.
+it and run the `log4shell` command in your terminal.  The tool can scan individual files, or whole directories.
 
 
 
@@ -146,11 +146,11 @@ $ log4shell
 
 :::note
 Please make sure that you're running this command on your fully built `.jar` or `.war` file. If you are
-using vendor software that you think might be vulnerable, but you can't get the `.jar` or `.war` files to scan yourself (or it is obfuscated), then you'll need to check out the [section on
+using vendor software that you think might be vulnerable, but you can't get the `.jar` or `.war` files to scan yourself (or if they are obfuscated), then you'll need to check out the [section on
 vendor software](#checking-vendor-software-versions) advisories instead.
 :::
 
-The source code for this is available on our GitHub 
+The source code for all of this is available on our GitHub 
 [here](https://github.com/lunasec-io/lunasec/tree/master/tools/log4shell/).
 
 ### Manually Scanning Your Dependencies
@@ -168,7 +168,7 @@ has a list of hashes that you can use to scan with. (Thank you, [hillu](https://
 You may want to simply scan the filesystem for vulnerable copies of the log4j `.jar` file.  We wrote a small shell script to accomplish
 that before writing the above CLI.
 
-This is a less accurate method of detection versus our automated scanner tool above because rather an inspecting inside your code,
+This is a less accurate method of detection as opposed to our automated scanner tool above because rather than inspecting inside your code,
 it requires the log4j `.jar` file to be present on your filesystem (not inside your built package). It _does not_ recursively unpack `.jar` files. This 
 works best if your dependencies are committed into your Repo, or if you're using a tool like Maven that downloads the 
 `.jar` files for you.  
@@ -218,15 +218,14 @@ Version 1 of log4j is vulnerable to other RCE attacks (like
 [migrate](https://logging.apache.org/log4j/2.x/manual/migration.html) to `2.17.0`.
 
 ### Checking Vendor Software Versions
-The above scanning tool might not work for vendor's packages because of obfuscation, and in any case, you'll likely need
+The above scanning tool may not work for vendor's packages due to obfuscation, and in any case, you'll likely need
 to contact the vendor for mitigation.
 
 Luckily, many vendors have created their own documents to explain the impact of Log4Shell on their products, and an extensive list
 of those advisories is being compiled [here](https://gist.github.com/SwitHak/b66db3a06c2955a9cb71a8718970c592).
 
 If a vendor has not created an advisory for this, there currently does not exist a succinct list of which Vendor 
-software has been affected. There is an effort by Kevin Beaumont to create a spreadsheet that attempts to capture this
-being worked on, but at this time of this post that effort is still a
+software has been affected. There is an effort by Kevin Beaumont to create a spreadsheet that attempts to capture this, but at the time of this post, that effort is still a
 [work in progress](https://twitter.com/GossiTheDog/status/1470181063980896262).
 
 ### Scanning Remote Endpoints
@@ -237,7 +236,7 @@ Please see our instructions to identify vulnerable remote servers in our origina
 Now that you know where you're vulnerable, the following sections will help you to figure out how to patch it.
 
 This diagram created by the [Swiss Government](https://www.govcert.ch/blog/zero-day-exploit-targeting-popular-java-library-log4j/) is an excellent
-visualization of the Log4Shell exploit.  Take note of the possible solutions (shown in red) as we go over mitigation strategies.  
+visualization of the Log4Shell exploit.  Take note of the possible solutions (shown in red), as we go over mitigation strategies.  
 
 <a href="https://www.lunasec.io/docs/img/log4j-attack-and-mitigations.png" target="_blank" rel="noopener">
   <img src="https://www.lunasec.io/docs/img/log4j-attack-and-mitigations.png" alt="log4shell 0day diagram" />
@@ -255,23 +254,23 @@ We recommend you upgrade, if possible.  For most people, this is the final and c
 
 :::caution Version 2.15.0 still may be vulnerable
 Log4j version `2.15.0` which was previously thought to be secure has been found to still have a [limited vulnerability](https://lists.apache.org/thread/83y7dx5xvn3h5290q1twn16tltolv88f), 
-that could result in a DOS (but not RCE), users must update to `>= 2.16.0`.
+that could result in a DOS (but not RCE). Users must update to `>= 2.16.0`.
 :::
 
 :::caution Version 2.16.0 vulnerable to DOS
-If you have updated Log4j to version `2.16.0`, a Denial of Service (DOS) attack is still present in [certain logging circumstances](https://logging.apache.org/log4j/2.x/security.html).
+If you have updated Log4j to version `2.16.0`, a vulnerability for a Denial of Service (DOS) attack is still present in [certain logging circumstances](https://logging.apache.org/log4j/2.x/security.html).
 :::
 
 ### Option 2: Enable `formatMsgNoLookups`
 :::warning This flag does not prevent all vulnerabilities
 As of Dec 14, it's been found that this flag is ineffective at stopping RCE in some situations,
-explained here [by log4j](https://logging.apache.org/log4j/2.x/security.html) and in
+explained here [by log4j](https://logging.apache.org/log4j/2.x/security.html), and in
 [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046). We found the CVE wording confusing and
 are still investigating this vulnerability.
 
-You must update to `2.17.0` or use the JNDI patches below.
+You must update to `2.17.0`, or use the JNDI patches below.
 :::
-The above release of log4j sets the `formatMsgNoLookups` flag to true by default, ~~preventing the attack~~.  If you are using log4j
+The above release of log4j sets the `formatMsgNoLookups` flag to true by default~~, preventing the attack~~.  If you are using log4j
 version `2.10.0` to version `2.14.0` and can't yet update, you can still set the flag manually.
 
 Set `formatMsgNoLookups=true` when you configure log4j by performing one of the following:
@@ -294,7 +293,7 @@ Or you can set this using the JVM arguments environment variable.
 
 ### Option 3: JNDI patch
 It's possible to [modify the JNDI in place](https://news.ycombinator.com/item?id=29507263) to stop the attack at the language level.
-It can even be done while the server is running with tools like
+This can even be done while the server is running with tools like
 [Log4jHotPatch](https://github.com/corretto/hotpatch-for-apache-log4j2) (as a temporary mitigation before updating log4j).
 
 [This guide](https://medium.com/@edeNFed/patching-log4shell-in-one-command-without-downtime-using-ephemeral-containers-c69a9155ab1e) 
@@ -309,10 +308,10 @@ If you need a long-term solution for patching vendor software, please check out 
 ### Option 4: Remote live patch for servers
 Because of the extensive control Log4Shell gives an attacker, it's actually possible to use the bug against itself to patch a running server.
 This isn't the recommended strategy for various reasons, but it could be a last resort for systems that you can't easily restart or modify.  Note that doing this on a system 
-you don't have permission to is most likely illegal. The fix will only work until the server (or the JVM) is restarted.
+you don't have permission to is most likely illegal. The fix will only work until the server (or the JVM), is restarted.
 
 We've published articles about this exploit that you can use to learn more about how it works.
-- **[Overview (When to use it)](https://www.lunasec.io/docs/blog/log4shell-live-patch/)**,
+- **[Overview (when to use the exploit)](https://www.lunasec.io/docs/blog/log4shell-live-patch/)**
 - **[Technical Deep-dive](https://www.lunasec.io/docs/blog/log4shell-live-patch-technical)**
 
 #### Hosted Exploit Payload
@@ -321,14 +320,14 @@ We've published articles about this exploit that you can use to learn more about
 ${jndi:ldap://patch.log4shell.com:1389/a}
 ```
 
-Using this will patch your server against future exploitation _until it restarts_. Just simply paste that anywhere into
-your server where you're vulnerable to use it. For example, in the `main` function when you start up your server, or a known
+Using this will patch your server against future exploitation _until it restarts_. Simply paste the above line anywhere into
+your server where you're vulnerable, to use it. For example, in the `main` function when you start up your server, or in a known
 vulnerable field if it's a vendor product you depend on.
 
 We have added this functionality to the [latest release](https://github.com/lunasec-io/lunasec/releases) of our
 Log4Shell CLI tool if you'd prefer to run the server yourself instead.
 
-:::warning Not permanent solution!
+:::warning Not a permanent solution!
 
 Please do not rely on this forever (in case our site ever goes down). This should only be used as a stop-gap solution
 until you can apply a more permanent patch for Log4Shell.
@@ -380,12 +379,12 @@ as a long-term defense against exploitation.
 
 ### A WAF will not save you from Log4Shell
 
-The Log4Shell vulnerability can _not_ be entirely mitigated by using a WAF (Web Application Firewall) because it _does not_
+The Log4Shell vulnerability can _not_ be entirely mitigated by using a WAF (Web Application Firewall), because it _does not_
 require your usage of it to be *publicly accessible*. Internal Data Pipelines, like Hadoop and Spark, and Desktop apps
 like the [NSA's Ghidra](https://twitter.com/NSA_CSDirector/status/1469305071116636167) will still be vulnerable.
 
 In addition, there is no simple way to "filter out" malicious requests with a simple WAF rule because Log4Shell payloads
-may be nested. (See [this GitHub](https://github.com/Puliczek/CVE-2021-44228-PoC-log4j-bypass-words) for examples)
+may be nested. (See [this GitHub](https://github.com/Puliczek/CVE-2021-44228-PoC-log4j-bypass-words) for examples.)
 
 If you are using a vulnerable version of log4j, the only secure way to mitigate Log4Shell is through one of the
 strategies detailed above.
@@ -418,7 +417,7 @@ recommend you follow one of the other mitigations instead.
 
 #### [OWASP Application Security Verification Standard](https://owasp.org/www-project-application-security-verification-standard/)
 
-This is a design framework that's being developed by the Open Web Application Security Project (OWASP) to help 
+This is a design framework that's being developed by the Open Web Application Security Project (OWASP), to help 
 standardize the levels of security that applications achieve. It provides a 
 solid baseline for setting up a security roadmap for your application.
 
@@ -428,12 +427,12 @@ _Spoiler: Maintained by us._
 
 An Open Source development framework that enables you to easily add a "Secure by Default" architecture to your existing
 software with only a few lines of code. It's loosely based on the OWASP Application Security Verification Standard 
-(above) and is also designed to be implemented in [multiple levels](https://www.lunasec.io/docs/pages/how-it-works/security/introduction/).
+(above), and is also designed to be implemented at [multiple levels](https://www.lunasec.io/docs/pages/how-it-works/security/introduction/).
 
 #### [Acra Database Protection](https://github.com/cossacklabs/acra)
 
 An Open Source database encryption library that helps you prevent data leaks by adding a layer of encryption to your 
-data. It's designed and maintained by Cossack Lab's, which also offers it as a commercial offering.
+data. It's designed and maintained by Cossack Labs, which also tenders it as a commercial offering.
 
 #### [FullHunt log4j Scanner](https://github.com/fullhunt/log4j-scan)
 
@@ -443,7 +442,7 @@ infrastructure. (Note: It's a new tool, so it might have bugs. Please file an is
 ### Stay In The Loop
 
 If you're currently dealing with Log4Shell and would like to stay updated, please follow us on
-[Twitter](https://twitter.com/LunaSecIO) or subscribe below to receive security updates as we post them.
+[Twitter](https://twitter.com/LunaSecIO), or subscribe below to receive security updates as we post them.
 
 import ContactForm from '../src/components/ContactForm.jsx'
 
@@ -451,7 +450,7 @@ import ContactForm from '../src/components/ContactForm.jsx'
 
 ### Additional Information
 
-We have published a series of posts about Log4Shell on our blog that you might be interested in:
+We have published a series of posts about Log4Shell on our blog that you may be interested in:
 - **[Original Log4Shell Announcement](https://www.lunasec.io/docs/blog/log4j-zero-day/)**,
 - **[Explanation of the 2nd Log4j CVE](https://www.lunasec.io/docs/blog/log4j-zero-day-update-on-cve-2021-45046/)**,
 - **[Part 1: Log4Shell Live Patch (Background Context)](https://www.lunasec.io/docs/blog/log4shell-live-patch/)**,
@@ -489,11 +488,11 @@ If you would like to contribute, or notice any errors, this post is an Open Sour
 
 1. Fixed some weird grammar.
 2. Added social links.
-3. Reworked some content. Added more options for mitigation. 
-4. Add warnings about limited vuln in 2.15 / noMsgFormatLookups
-5. Add additional disclaimer about %m.
+3. Reworked some content and added more options for mitigation. 
+4. Added warnings about limited vuln in 2.15 / noMsgFormatLookups.
+5. Added additional disclaimer about %m.
 6. Added link to 2nd CVE info.
 7. Added info about hot patching, and links to new releases.
-8. Update info about patching strategies.
+8. Updated info about patching strategies.
 9. Added links to other blog posts.
-10. Updated info about 2.16.0 CVE telling users to upgrade to 2.17.0 now
+10. Updated info about 2.16.0 CVE telling users to upgrade to 2.17.0 now.

--- a/docs/blog/2021-12-12-log4j-zero-day-mitigation-guide.mdx
+++ b/docs/blog/2021-12-12-log4j-zero-day-mitigation-guide.mdx
@@ -49,16 +49,15 @@ Because of the severe impact from this vulnerability, there has been a lot of di
 about it. **Some of this information is outdated or wrong and _will_ leave you vulnerable if you follow it!**
 
 By contrast, this guide has been written by a team of professional Security Engineers at LunaSec. Everything here has
-been peer-reviewed by multiple security experts, and where possible our sources will be linked from other Security
-professionals to verify against.  This post links to many other guides and how-tos that we believe are trustworthy.  
+been peer-reviewed by multiple security experts, and where possible our sources will be linked for other Security
+professionals.  This post links to many other guides and how-tos that we believe are trustworthy.  
 
 The full list of common bad advice is at the [bottom of this post](#known-bad-advice). If you believe you've already 
 mitigated Log4Shell, or you believe you're not vulnerable, please double-check that your current information is up-to-date. 
 
 ## Determine if you are impacted by Log4Shell
 
-This vulnerability affects anybody who's using the log4j packages. That means that
-primarily Java, but also other languages like Scala, Groovy, or Clojure, are impacted.
+This vulnerability affects anybody who's using the log4j packages. Java consequently is primarily affected, but other languages like Scala, Groovy, and Clojure are also impacted.
 
 ### Automatically Scanning Your Package
 
@@ -150,7 +149,7 @@ using vendor software that you think might be vulnerable, but you can't get the 
 vendor software](#checking-vendor-software-versions) advisories instead.
 :::
 
-The source code for all of this is available on our GitHub 
+The source code for this tool is available on our GitHub 
 [here](https://github.com/lunasec-io/lunasec/tree/master/tools/log4shell/).
 
 ### Manually Scanning Your Dependencies
@@ -310,8 +309,7 @@ Because of the extensive control Log4Shell gives an attacker, it's actually poss
 This isn't the recommended strategy for various reasons, but it could be a last resort for systems that you can't easily restart or modify.  Note that doing this on a system 
 you don't have permission to is most likely illegal. The fix will only work until the server (or the JVM), is restarted.
 
-We've published articles about this exploit that you can use to learn more about how it works.
-- **[Overview (when to use the exploit)](https://www.lunasec.io/docs/blog/log4shell-live-patch/)**
+We have built a live-patching tool and a hosted live-patching server to make this easy. Please see [our post](https://www.lunasec.io/docs/blog/log4shell-live-patch/) about these tools to learn more.
 - **[Technical Deep-dive](https://www.lunasec.io/docs/blog/log4shell-live-patch-technical)**
 
 #### Hosted Exploit Payload
@@ -427,7 +425,7 @@ _Spoiler: Maintained by us._
 
 An Open Source development framework that enables you to easily add a "Secure by Default" architecture to your existing
 software with only a few lines of code. It's loosely based on the OWASP Application Security Verification Standard 
-(above), and is also designed to be implemented at [multiple levels](https://www.lunasec.io/docs/pages/how-it-works/security/introduction/).
+(above), and is also designed to be [adopted gradually](https://www.lunasec.io/docs/pages/how-it-works/security/introduction/).
 
 #### [Acra Database Protection](https://github.com/cossacklabs/acra)
 

--- a/docs/blog/2021-12-14-log4j-zero-day-update-on-CVE-2021-45046.mdx
+++ b/docs/blog/2021-12-14-log4j-zero-day-update-on-CVE-2021-45046.mdx
@@ -38,18 +38,18 @@ Our research into this shows that this new CVE invalidates previous mitigations 
 
 ## Conditions for the vulnerability
 
-You may still be vulnerable to Log4Shell (RCE) if you only enabled the `formatMsgNoLookups` flag or set
+You may still be vulnerable to Log4Shell (RCE), if you only enabled the `formatMsgNoLookups` flag or set
 `%m{nolookups}` when you also set data in the `ThreadContext` with attacker controlled data. In this case, you must
-upgrade to `>= 2.15.0` or else you will still be vulnerable to RCE.
+upgrade to `>= 2.15.0`, or else you will still be vulnerable to RCE.
 
 :::note For version `2.15.0`
-** Update ** There has been a limited RCE discovered in `2.15.0` and the [severity has been upgraded](https://www.lunasec.io/docs/blog/log4j-zero-day-severity-of-cve-2021-45046-increased/)
+** Update ** There has been a limited RCE discovered in `2.15.0`, and the [severity has been upgraded](https://www.lunasec.io/docs/blog/log4j-zero-day-severity-of-cve-2021-45046-increased/)
 from `3.7 -> 9.0`.
 
 We found that the DOS outlined in the CVE was not actually impactful because it did not consume resources
 during our testing (see [below](#notes-on-the-denial-of-service-in-2.15.0)).
 
-We could still be wrong through, so we continue to recommend that you upgrade to `2.17.0` in the event that a better
+We could still be wrong though, so we continue to recommend that you upgrade to `2.17.0` in the event that a better
 exploit is found to abuse this attack vector.
 :::
 
@@ -83,7 +83,7 @@ triggered. That's why we actually tested this ourselves to figure out what the i
 ## Testing previous mitigations
 
 Fortunately the community has been hard at work reacting to these updates. A fork of
-[christophetd/log4shell-vulnerable-app](https://github.com/christophetd/log4shell-vulnerable-app)
+[christophetd/log4shell-vulnerable-app](https://github.com/christophetd/log4shell-vulnerable-app) has
 [added some changes](https://github.com/kmindi/log4shell-vulnerable-app/commit/e539f7e9a0c81e2c580d63caff5f4eae14033f19)
 to demonstrate the specific scenario in which this newly found CVE could affect an application.
 
@@ -133,7 +133,7 @@ public String index(@RequestHeader("X-Api-Version") String apiVersion) {
 
 :::info Vulnerable App Log4j version
 
-This vulnerable application was running with Log4j version `2.14.1` which is still vulnerable to the RCE even
+This vulnerable application was running with Log4j version `2.14.1`, which is still vulnerable to the RCE even
 _before_ the `LOG4J_FORMAT_MSG_NO_LOOKUPS` mitigation.
 
 :::
@@ -142,7 +142,7 @@ _before_ the `LOG4J_FORMAT_MSG_NO_LOOKUPS` mitigation.
 
 ### Issues when using `log4j2.formatMsgNoLookups` (>=2.10.0)
 
-Running this vulnerable server and exploiting the vulnerability with our [log4shell CLI tool](https://github.com/lunasec-io/lunasec/tree/master/tools/log4shell)
+Running this vulnerable server and exploiting the vulnerability with our [log4shell CLI tool](https://github.com/lunasec-io/lunasec/tree/master/tools/log4shell),
 we observed that RCE was still possible in versions `2.10.0 <= Apache log4j < 2.14.1`:
 
 <a href="https://www.lunasec.io/docs/img/log4shell-CVE-2021-45046-exploitation-with-mitigation.png" target="_blank" rel="noopener">
@@ -167,39 +167,39 @@ for additional steps you can take to remediate the impact of Log4Shell.
 
 ### Setting `%m{nolookups}` is still vulnerable (>=2.7.0)
 
-We continue to recommend _not_ using `%m{nolookups}`, which we outline in our [mitigation guide](https://www.lunasec.io/docs/blog/log4j-zero-day-mitigation-guide), as we have also
-proved the vulnerability is still exploitable with a Pattern Layout such as:
+We continue to recommend _not_ using `%m{nolookups}`, which we outline in our [mitigation guide](https://www.lunasec.io/docs/blog/log4j-zero-day-mitigation-guide), as we have
+proven the vulnerability is still exploitable with a Pattern Layout such as:
 
 ```
 appender.console.layout.pattern = ${ctx:apiversion} - %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m{nolookups}%n
 ```
 
-`%m{nolookups}` will only apply to the content being logged in the call to `logger.info()` and will not apply to the
+`%m{nolookups}` will only apply to the content being logged in the call to `logger.info()`, and will not apply to the
 resolving of `${ctx:apiversion}` which will contain our payload.
 
 ### Notes on the Denial-of-Service in 2.15.0
 
-** Update ** There has been a limited RCE discovered in `2.15.0` and the [severity has been upgraded](https://www.lunasec.io/docs/blog/log4j-zero-day-severity-of-cve-2021-45046-increased/)
+** Update ** There has been a limited RCE discovered in `2.15.0`, and the [severity has been upgraded](https://www.lunasec.io/docs/blog/log4j-zero-day-severity-of-cve-2021-45046-increased/)
 from `3.7 -> 9.0`.
 
 The less impactful part of this CVE, if you have updated your Log4j version to `2.15.0`, is that there is a limited
-denial of service (DOS) possible under certain circumstances. See the below screenshot:
+denial of service (DOS), possible under certain circumstances. See the below screenshot:
 
 <a href="https://www.lunasec.io/docs/img/log4shell-CVE-2021-45046-dos-with-mitigation.png" target="_blank" rel="noopener">
   <img src="https://www.lunasec.io/docs/img/log4shell-CVE-2021-45046-dos-with-mitigation.png" alt="Log4j DOS on log4j 2.15.0 with mitigation" />
 </a>
 
-However, in our testing we did not find this DOS to be resource consuming as it seemed that the infinite loop created by recursively
+However, in our testing we did not find this DOS to be resource consuming, as it seemed that the infinite loop created by recursively
 resolving `${ctx:apiversion}` was identified by the program and errored out.
 
-Log4j `2.16.0` completely mitigates this issue by `removing support for message lookup patterns and disabling JNDI functionality by default`. (Note: Please use `2.17.0` or newer though to mitigate other security issues in `2.16.0`)
+Log4j `2.16.0` completely mitigates this issue by removing support for message lookup patterns and disabling JNDI functionality by default. Please use `2.17.0` or newer however to mitigate other security issues in `2.16.0`.
 
 ## Stay Updated
 
 Please follow us on [Twitter](https://twitter.com/LunaSecIO) or add yourself to our mailing list below, and we'll
 update you when we publish new findings.
 
-And if this post helped you, please share it with others to help them too.
+If this post helped you, please share it with others to help them too.
 
 import ContactForm from '../src/components/ContactForm.jsx'
 
@@ -208,9 +208,9 @@ import ContactForm from '../src/components/ContactForm.jsx'
 ## Additional Information
 
 We have published a series of posts about Log4Shell on our blog that you might be interested in:
-- **[Mitigation Guide](https://www.lunasec.io/docs/blog/log4j-zero-day-mitigation-guide/)**,
-- **[Original Log4Shell Announcement](https://www.lunasec.io/docs/blog/log4j-zero-day/)**,
-- **[Part 1: Log4Shell Live Patch (Background Context)](https://www.lunasec.io/docs/blog/log4shell-live-patch/)**,
+- **[Mitigation Guide](https://www.lunasec.io/docs/blog/log4j-zero-day-mitigation-guide/)**
+- **[Original Log4Shell Announcement](https://www.lunasec.io/docs/blog/log4j-zero-day/)**
+- **[Part 1: Log4Shell Live Patch (Background Context)](https://www.lunasec.io/docs/blog/log4shell-live-patch/)**
 - **[Part 2: Log4Shell Live Patch (Technical Deep-Dive)](https://www.lunasec.io/docs/blog/log4shell-live-patch-technical/)**
 
 ### Limited Offer: Free Security Assistance
@@ -228,8 +228,8 @@ If you would like to contribute, or notice any errors, this post is an Open Sour
 [GitHub](https://github.com/lunasec-io/lunasec/blob/master/docs/blog/2021-12-14-log4j-zero-day-update-on-CVE-2021-45046.mdx).
 :::
 
-1. Updated 12/15/21: Updated "Conditions for the Vulnerability" section from "upgrade to `2.16.0`" to "upgrade to `>= 2.15.0`", see [this GitHub issue](https://github.com/lunasec-io/lunasec/issues/316)
-2. Updated 12/15/21: Updated all instances of `noFormatMsgLookup` to be the correct `formatMsgNoLookups`, see [this GitHub issue](https://github.com/lunasec-io/lunasec/issues/317)
+1. Updated 12/15/21: Updated "Conditions for the Vulnerability" section from "upgrade to `2.16.0`" to "upgrade to `>= 2.15.0`", see [this GitHub issue](https://github.com/lunasec-io/lunasec/issues/316).
+2. Updated 12/15/21: Updated all instances of `noFormatMsgLookup` to be the correct `formatMsgNoLookups`, see [this GitHub issue](https://github.com/lunasec-io/lunasec/issues/317).
 3. Updated 12/16/21: Added links to other blog posts.
 4. Updated 12/18/21: Updated note about 2.15.0 that RCE has been found.
 5. Updated 12/19/21: Updated advice about 2.16.0 to recommend 2.17.0 now.

--- a/docs/blog/2021-12-14-log4j-zero-day-update-on-CVE-2021-45046.mdx
+++ b/docs/blog/2021-12-14-log4j-zero-day-update-on-CVE-2021-45046.mdx
@@ -49,7 +49,7 @@ from `3.7 -> 9.0`.
 We found that the DOS outlined in the CVE was not actually impactful because it did not consume resources
 during our testing (see [below](#notes-on-the-denial-of-service-in-2.15.0)).
 
-We could still be wrong though, so we continue to recommend that you upgrade to `2.17.0` in the event that a better
+Our reproduction could be incomplete however, so we continue to recommend that you upgrade to `2.17.0` in the event that a better
 exploit is found to abuse this attack vector.
 :::
 
@@ -167,7 +167,7 @@ for additional steps you can take to remediate the impact of Log4Shell.
 
 ### Setting `%m{nolookups}` is still vulnerable (>=2.7.0)
 
-We continue to recommend _not_ using `%m{nolookups}`, which we outline in our [mitigation guide](https://www.lunasec.io/docs/blog/log4j-zero-day-mitigation-guide), as we have
+We continue to recommend _not_ using `%m{nolookups}`, as explained in our [mitigation guide](https://www.lunasec.io/docs/blog/log4j-zero-day-mitigation-guide), since we have
 proven the vulnerability is still exploitable with a Pattern Layout such as:
 
 ```
@@ -192,14 +192,13 @@ denial of service (DOS), possible under certain circumstances. See the below scr
 However, in our testing we did not find this DOS to be resource consuming, as it seemed that the infinite loop created by recursively
 resolving `${ctx:apiversion}` was identified by the program and errored out.
 
-Log4j `2.16.0` completely mitigates this issue by removing support for message lookup patterns and disabling JNDI functionality by default. Please use `2.17.0` or newer however to mitigate other security issues in `2.16.0`.
-
+Log4j `2.16.0` completely mitigates this issue by removing support for message lookup patterns and disabling JNDI functionality by default. `2.16.0` has its own issues, however, so please upgrade to `2.17.0` or newer.
 ## Stay Updated
 
 Please follow us on [Twitter](https://twitter.com/LunaSecIO) or add yourself to our mailing list below, and we'll
 update you when we publish new findings.
 
-If this post helped you, please share it with others to help them too.
+If this post helped you, please share it with others.
 
 import ContactForm from '../src/components/ContactForm.jsx'
 


### PR DESCRIPTION
Line 106 of zero-day-update is a sentence fragment.  I don't know enough about the vulnerability to rewrite it, but it may or may not need revision, at the very least it looked unclear. 

"Now, instead of directly logging the attacker controlled input as with the previous vulnerability like this:"   

"instead of" implies that there will be an alternative presented.   Is it presented in the next paragraph?  I could not tell.  
