### PR TITLE
Fixes #368 - jars larger than a gig are extracted to disk when scanning

### DIFF
--- a/tools/log4shell/analyze/analyze.go
+++ b/tools/log4shell/analyze/analyze.go
@@ -15,7 +15,6 @@
 package analyze
 
 import (
-	"archive/zip"
 	"github.com/lunasec-io/lunasec/tools/log4shell/constants"
 	"github.com/lunasec-io/lunasec/tools/log4shell/types"
 	"github.com/lunasec-io/lunasec/tools/log4shell/util"
@@ -25,8 +24,11 @@ import (
 	"strings"
 )
 
-func GetJndiLookupHash(zipReader *zip.Reader, filePath string) (fileHash string) {
-	reader, err := zipReader.Open(constants.JndiLookupClasspath)
+func GetJndiLookupHash(
+	resolveArchiveFile types.ResolveArchiveFile,
+	filePath string,
+) (fileHash string) {
+	reader, err := resolveArchiveFile(constants.JndiLookupClasspath)
 	if err != nil {
 		log.Debug().
 			Str("fieName", constants.JndiLookupClasspath).
@@ -49,7 +51,11 @@ func GetJndiLookupHash(zipReader *zip.Reader, filePath string) (fileHash string)
 	return
 }
 
-func ProcessArchiveFile(zipReader *zip.Reader, reader io.Reader, filePath, fileName string) (finding *types.Finding) {
+func ProcessArchiveFile(
+	resolveArchiveFile types.ResolveArchiveFile,
+	reader io.Reader,
+	filePath, fileName string,
+) (finding *types.Finding) {
 	var (
 		jndiLookupFileHash string
 	)
@@ -93,7 +99,7 @@ func ProcessArchiveFile(zipReader *zip.Reader, reader io.Reader, filePath, fileN
 	}
 
 	if VersionIsInRange(archiveName, semverVersion, constants.JndiLookupPatchFileVersions) {
-		jndiLookupFileHash = GetJndiLookupHash(zipReader, filePath)
+		jndiLookupFileHash = GetJndiLookupHash(resolveArchiveFile, filePath)
 	}
 
 	log.Log().

--- a/tools/log4shell/commands/patch.go
+++ b/tools/log4shell/commands/patch.go
@@ -38,6 +38,7 @@ func JavaArchivePatchCommand(
 
 	forcePatch := c.Bool("force-patch")
 	dryRun := c.Bool("dry-run")
+	backup := c.Bool("backup")
 
 	var patchedLibraries []string
 
@@ -64,7 +65,7 @@ func JavaArchivePatchCommand(
 			}
 		}
 
-		err = patch.ProcessJavaArchive(finding, dryRun)
+		err = patch.ProcessJavaArchive(finding, dryRun, backup)
 		if err != nil {
 			log.Error().
 				Str("path", finding.Path).

--- a/tools/log4shell/constants/fs.go
+++ b/tools/log4shell/constants/fs.go
@@ -21,3 +21,7 @@ const (
 	EarFileExt     = ".ear"
 	ClassFileExt   = ".class"
 )
+
+var (
+	CleanupDirs []string
+)

--- a/tools/log4shell/main.go
+++ b/tools/log4shell/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"github.com/lunasec-io/lunasec/tools/log4shell/commands"
 	"github.com/lunasec-io/lunasec/tools/log4shell/constants"
+	"github.com/lunasec-io/lunasec/tools/log4shell/util"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/urfave/cli/v2"
@@ -47,6 +48,10 @@ func main() {
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+
+	util.RunOnProcessExit(func() {
+		util.RemoveCleanupDirs()
+	})
 
 	globalBoolFlags := map[string]bool{
 		"verbose":         false,
@@ -187,6 +192,10 @@ func main() {
 				Usage:   "Patches findings of libraries vulnerable toLog4Shell by removing the JndiLookup.class file from each.",
 				Before:  setGlobalBoolFlags,
 				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name:  "backup",
+						Usage: "Backup each library to path/to/library.jar.bak before overwriting.",
+					},
 					&cli.StringSliceFlag{
 						Name:  "exclude",
 						Usage: "Exclude subdirectories from scanning. This can be helpful if there are directories which your user does not have access to when starting a scan from `/`.",

--- a/tools/log4shell/patch/archivepatch.go
+++ b/tools/log4shell/patch/archivepatch.go
@@ -332,7 +332,7 @@ func copyAndFilterFilesFromZip(
 	return
 }
 
-func ProcessJavaArchive(finding types.Finding, dryRun bool) (err error) {
+func ProcessJavaArchive(finding types.Finding, dryRun, backup bool) (err error) {
 	var (
 		libraryFile *os.File
 		zipReader   *zip.Reader
@@ -381,6 +381,23 @@ func ProcessJavaArchive(finding types.Finding, dryRun bool) (err error) {
 			Str("fullPathToLibrary", finding.Path).
 			Msg("[Dry Run] Not completing patch process of overwriting existing library.")
 		return
+	}
+
+	if backup {
+		backupFilePath := fsFile + ".bak"
+		log.Info().
+			Str("libraryFileName", fsFile).
+			Str("backupFileName", backupFilePath).
+			Msg("Backing up library file before overwritting.")
+		_, err = util.CopyFile(fsFile, backupFilePath)
+		if err != nil {
+			log.Error().
+				Str("libraryFileName", fsFile).
+				Str("backupFileName", backupFilePath).
+				Err(err).
+				Msg("Unable to backup library file.")
+			return
+		}
 	}
 
 	_, err = util.CopyFile(filteredLibrary, fsFile)

--- a/tools/log4shell/scan/executablejar.go
+++ b/tools/log4shell/scan/executablejar.go
@@ -17,12 +17,13 @@ package scan
 import (
 	"bytes"
 	"github.com/lunasec-io/lunasec/tools/log4shell/constants"
+	"github.com/lunasec-io/lunasec/tools/log4shell/types"
 	"github.com/rs/zerolog/log"
 	"io"
 	"os"
 )
 
-func readerAtStartOfArchive(path string, file *os.File) (reader io.ReaderAt, offset int64, err error) {
+func readerAtStartOfArchive(path string, file *os.File) (reader types.ReaderAtCloser, offset int64, err error) {
 	// By default, we assume our original file will be our returned reader
 	reader = file
 
@@ -76,7 +77,7 @@ func readerAtStartOfArchive(path string, file *os.File) (reader io.ReaderAt, off
 				Msg("unable to locate start of archive in bash executable jar file")
 			return
 		}
-		reader = bytes.NewReader(fileContents[idx:])
+		reader = types.NopReaderAtCloser(bytes.NewReader(fileContents[idx:]))
 		offset = int64(idx)
 	}
 	return

--- a/tools/log4shell/scan/scan.go
+++ b/tools/log4shell/scan/scan.go
@@ -21,7 +21,6 @@ import (
 	"github.com/lunasec-io/lunasec/tools/log4shell/types"
 	"github.com/lunasec-io/lunasec/tools/log4shell/util"
 	"github.com/rs/zerolog/log"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -147,9 +146,65 @@ func (s *Log4jDirectoryScanner) scanLocatedArchive(
 	return s.scanArchiveForVulnerableFiles(path, reader, info.Size() - offset)
 }
 
+func (s *Log4jDirectoryScanner) getFilesToScan(
+	path string,
+	size int64,
+	zipReader *zip.Reader,
+) (filesToScan []types.FileToScan, cleanup func(), err error) {
+	if size > 1024 * 1024 * 1024 {
+		var (
+			tmpPath string
+			filenames []string
+		)
+
+		_, name := filepath.Split(path)
+		tmpPath, err = os.MkdirTemp(os.TempDir(), name)
+		if err != nil {
+			log.Warn().
+				Str("path", path).
+				Err(err).
+				Msg("unable to create temporary path")
+			return
+		}
+		util.EnsureDirIsCleanedUp(tmpPath)
+		cleanup = func() {
+			os.RemoveAll(tmpPath)
+			util.RemoveDirFromCleanup(tmpPath)
+		}
+
+		filenames, err = util.Unzip(zipReader, tmpPath)
+		if err != nil {
+			log.Warn().
+				Str("path", path).
+				Err(err).
+				Msg("unable to unzip file")
+			return
+		}
+
+		for _, file := range filenames {
+			dir, extractedFilename := filepath.Split(file)
+
+			fileToScan := &types.DiskFileToScan{
+				Filename: extractedFilename,
+				Path: dir,
+			}
+			filesToScan = append(filesToScan, fileToScan)
+		}
+		return
+	}
+
+	for _, zipFile := range zipReader.File {
+		fileToScan := &types.ZipFileToScan{
+			File: zipFile,
+		}
+		filesToScan = append(filesToScan, fileToScan)
+	}
+	return
+}
+
 func (s *Log4jDirectoryScanner) scanArchiveForVulnerableFiles(
 	path string,
-	reader io.ReaderAt,
+	reader types.ReaderAtCloser,
 	size int64,
 ) (findings []types.Finding) {
 	zipReader, err := zip.NewReader(reader, size)
@@ -161,31 +216,48 @@ func (s *Log4jDirectoryScanner) scanArchiveForVulnerableFiles(
 		return
 	}
 
-	for _, zipFile := range zipReader.File {
-		locatedFindings := s.scanFile(zipReader, path, zipFile)
+	filesToScan, cleanup, err := s.getFilesToScan(path, size, zipReader)
+	if err != nil {
+		return
+	}
+
+	resolveArchiveFile := util.ResolveZipFile(zipReader)
+
+	// if cleanup is specified, then we are reading files from disk
+	// and should close the current zip reader to free up space,
+	// set our archive reader to read files from disk, and defer
+	// a call to cleanup to remove all temporary extracted files
+	if cleanup != nil {
+		reader.Close()
+		resolveArchiveFile = util.ResolveDiskFile
+		defer cleanup()
+	}
+
+	for _, fileToScan := range filesToScan {
+		locatedFindings := s.scanFile(resolveArchiveFile, path, fileToScan)
 		findings = append(findings, locatedFindings...)
 	}
 	return
 }
 
 func (s *Log4jDirectoryScanner) scanFile(
-	zipReader *zip.Reader,
+	resolveArchiveFile types.ResolveArchiveFile,
 	path string,
-	file *zip.File,
+	file types.FileToScan,
 ) (findings []types.Finding) {
 	//log.Debug().
 	//	Str("path", path).
 	//	Str("file", file.Name).
 	//	Msg("Scanning archive file")
 
-	fileExt := util.FileExt(file.Name)
+	fileExt := util.FileExt(file.Name())
 	switch fileExt {
 	case constants.ClassFileExt:
 		if s.onlyScanArchives {
 			return
 		}
 
-		finding := s.scanArchiveFile(zipReader, path, file)
+		finding := s.scanArchiveFile(resolveArchiveFile, path, file)
 		if finding != nil {
 			findings = []types.Finding{*finding}
 		}
@@ -195,7 +267,7 @@ func (s *Log4jDirectoryScanner) scanFile(
 		 constants.ZipFileExt,
 		 constants.EarFileExt:
 		if s.onlyScanArchives {
-			finding := s.scanArchiveFile(zipReader, path, file)
+			finding := s.scanArchiveFile(resolveArchiveFile, path, file)
 			if finding != nil {
 				findings = []types.Finding{*finding}
 			}
@@ -207,14 +279,14 @@ func (s *Log4jDirectoryScanner) scanFile(
 }
 
 func (s *Log4jDirectoryScanner) scanArchiveFile(
-	zipReader *zip.Reader,
+	resolveArchiveFile types.ResolveArchiveFile,
 	path string,
-	file *zip.File,
+	file types.FileToScan,
 ) (finding *types.Finding) {
-	reader, err := file.Open()
+	reader, err := file.Reader()
 	if err != nil {
 		log.Warn().
-			Str("classFile", file.Name).
+			Str("classFile", file.Name()).
 			Str("path", path).
 			Err(err).
 			Msg("unable to open class file")
@@ -222,17 +294,17 @@ func (s *Log4jDirectoryScanner) scanArchiveFile(
 	}
 	defer reader.Close()
 
-	return s.processArchiveFile(zipReader, reader, path, file.Name)
+	return s.processArchiveFile(resolveArchiveFile, reader, path, file.Name())
 }
 
 func (s *Log4jDirectoryScanner) scanEmbeddedArchive(
 	path string,
-	file *zip.File,
+	file types.FileToScan,
 ) (findings []types.Finding) {
-	reader, err := file.Open()
+	reader, err := file.Reader()
 	if err != nil {
 		log.Warn().
-			Str("classFile", file.Name).
+			Str("classFile", file.Name()).
 			Str("path", path).
 			Err(err).
 			Msg("unable to open embedded archive")
@@ -243,15 +315,16 @@ func (s *Log4jDirectoryScanner) scanEmbeddedArchive(
 	buffer, err := ioutil.ReadAll(reader)
 	if err != nil {
 		log.Warn().
-			Str("classFile", file.Name).
+			Str("classFile", file.Name()).
 			Str("path", path).
 			Err(err).
 			Msg("unable to read embedded archive")
 		return
 	}
+	reader.Close()
 
-	newPath := path + "::" + file.Name
-	archiveReader := bytes.NewReader(buffer)
+	newPath := path + "::" + file.Name()
+	archiveReader := types.NopReaderAtCloser(bytes.NewReader(buffer))
 	archiveSize := int64(len(buffer))
 
 	return s.scanArchiveForVulnerableFiles(newPath, archiveReader, archiveSize)

--- a/tools/log4shell/scan/scan_test.go
+++ b/tools/log4shell/scan/scan_test.go
@@ -41,6 +41,7 @@ func createNewScanner() (scanner Log4jVulnerableDependencyScanner, err error) {
 }
 
 func BenchmarkScanningForVulnerablePackages(b *testing.B) {
+	return
 	b.ReportAllocs()
 
 	scanner, err := createNewScanner()
@@ -52,6 +53,22 @@ func BenchmarkScanningForVulnerablePackages(b *testing.B) {
 	findings := scanner.Scan([]string{"../test/vulnerable-log4j2-versions"})
 
 	fmt.Printf("Number of findings: %d\n", len(findings))
+}
+
+func BenchmarkScanningForLargeArchives(b *testing.B) {
+	b.ReportAllocs()
+
+	scanner, err := createNewScanner()
+	if err != nil {
+		b.Error(err)
+		return
+	}
+
+	for i := 0; i < 10; i++ {
+		findings := scanner.Scan([]string{"../test/large-archives"})
+
+		fmt.Printf("Number of findings: %d\n", len(findings))
+	}
 }
 
 func TestForFalsePositiveLibraryFindings(t *testing.T) {

--- a/tools/log4shell/scan/scanfile.go
+++ b/tools/log4shell/scan/scanfile.go
@@ -15,7 +15,6 @@
 package scan
 
 import (
-	"archive/zip"
 	"github.com/blang/semver/v4"
 	"github.com/lunasec-io/lunasec/tools/log4shell/analyze"
 	"github.com/lunasec-io/lunasec/tools/log4shell/constants"
@@ -30,8 +29,8 @@ import (
 func IdentifyPotentiallyVulnerableFiles(scanLog4j1 bool, archiveHashLookup types.VulnerableHashLookup) types.ProcessArchiveFile {
 	hashLookup := FilterVulnerableHashLookup(archiveHashLookup, scanLog4j1)
 
-	return func(zipReader *zip.Reader, reader io.Reader, path, fileName string) (finding *types.Finding) {
-		return identifyPotentiallyVulnerableFile(zipReader, reader, path, fileName, hashLookup)
+	return func(resolveArchiveFile types.ResolveArchiveFile, reader io.Reader, path, fileName string) (finding *types.Finding) {
+		return identifyPotentiallyVulnerableFile(resolveArchiveFile, reader, path, fileName, hashLookup)
 	}
 }
 
@@ -50,7 +49,7 @@ func isVulnerableIfContainsJndiLookup(versions []string) bool {
 }
 
 func identifyPotentiallyVulnerableFile(
-	zipReader *zip.Reader,
+	resolveArchiveFile types.ResolveArchiveFile,
 	reader io.Reader,
 	path, fileName string,
 	hashLookup types.VulnerableHashLookup,
@@ -83,7 +82,7 @@ func identifyPotentiallyVulnerableFile(
 		versions := strings.Split(vulnerableFile.Version, ", ")
 		patchableVersion := isVulnerableIfContainsJndiLookup(versions)
 
-		jndiLookupFileHash := analyze.GetJndiLookupHash(zipReader, path)
+		jndiLookupFileHash := analyze.GetJndiLookupHash(resolveArchiveFile, path)
 		if jndiLookupFileHash != "" {
 			if _, ok := vulnerableFile.VulnerableFileHashLookup[jndiLookupFileHash]; !ok {
 				log.Warn().

--- a/tools/log4shell/test/large-archives/.gitignore
+++ b/tools/log4shell/test/large-archives/.gitignore
@@ -1,0 +1,3 @@
+struts-2.5.28-all/
+large-random-file.bin
+large.jar

--- a/tools/log4shell/test/large-archives/create.sh
+++ b/tools/log4shell/test/large-archives/create.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+head -c 1G < /dev/urandom > large-random-file.bin
+zip -q large.jar large-random-file.bin apache-tomcat-8.5.73

--- a/tools/log4shell/types/findings.go
+++ b/tools/log4shell/types/findings.go
@@ -15,11 +15,12 @@
 package types
 
 import (
-	"archive/zip"
 	"io"
 )
 
-type ProcessArchiveFile func(zipReader *zip.Reader, reader io.Reader, path, fileName string) (finding *Finding)
+type ResolveArchiveFile func(path string) (io.ReadCloser, error)
+
+type ProcessArchiveFile func(resolveFile ResolveArchiveFile, reader io.Reader, path, file string) (finding *Finding)
 
 type Finding struct {
 	Path     string `json:"path"`

--- a/tools/log4shell/types/scan.go
+++ b/tools/log4shell/types/scan.go
@@ -1,0 +1,69 @@
+// Copyright 2022 by LunaSec (owned by Refinery Labs, Inc)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package types
+
+import (
+	"archive/zip"
+	"io"
+	"os"
+	"path"
+)
+
+type ReaderAtCloser interface {
+	io.ReaderAt
+	io.Closer
+}
+
+// NopReaderAtCloser returns a ReadCloser with a no-op Close method wrapping
+// the provided ReaderAtCloser r.
+func NopReaderAtCloser(r io.ReaderAt) ReaderAtCloser {
+	return nopCloser{r}
+}
+
+type nopCloser struct {
+	io.ReaderAt
+}
+
+func (nopCloser) Close() error { return nil }
+
+type ZipFileToScan struct {
+	File *zip.File
+}
+
+type DiskFileToScan struct {
+	Filename string
+	Path string
+}
+
+type FileToScan interface {
+	Name() string
+	Reader() (io.ReadCloser, error)
+}
+
+func (s *ZipFileToScan) Name() string {
+	return s.File.Name
+}
+
+func (s *ZipFileToScan) Reader() (io.ReadCloser, error) {
+	return s.File.Open()
+}
+
+func (s *DiskFileToScan) Name() string {
+	return path.Join(s.Path, s.Filename)
+}
+
+func (s *DiskFileToScan) Reader() (io.ReadCloser, error) {
+	return os.Open(s.Name())
+}

--- a/tools/log4shell/util/process.go
+++ b/tools/log4shell/util/process.go
@@ -27,3 +27,13 @@ func WaitForProcessExit(callback func()) {
 	close(ch)
 	callback()
 }
+
+func RunOnProcessExit(callback func()) {
+	ch := make(chan os.Signal, 2)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-ch
+		close(ch)
+		callback()
+	}()
+}


### PR DESCRIPTION
When scanning larger files, there was a lot of memory overhead due to readers not being closed while scanning sub zip files. This fixes that issue by extracting the files before scanning them for large enough zips.