### PR TITLE
merge conflict mitigation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,0 @@
-lunatrace/bsl/frontend/schema.graphql merge=ours
-lunatrace/bsl/backend/schema.graphql merge=ours
-lunatrace/bsl/frontend/public/css merge=ours
-lunatrace/bsl/frontend/src/api/generated.ts merge=ours
-lunatrace/bsl/backend/src/asura-api/generated.ts merge=ours

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+lunatrace/bsl/frontend/schema.graphql merge=ours
+lunatrace/bsl/backend/schema.graphql merge=ours
+lunatrace/bsl/frontend/public/css merge=ours
+lunatrace/bsl/frontend/src/api/generated.ts merge=ours
+lunatrace/bsl/backend/src/asura-api/generated.ts merge=ours

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ docs/.yarn/.cache/webpack
 .eslintcache
 
 
+.gitattributes


### PR DESCRIPTION
this is an attempt to mitigate merge conflicts for our many, many generated files using a merge strategy.  This is local only, to prevent it happening in build machines 

Add the file to your project root .gitattributes
```
lunatrace/bsl/frontend/schema.graphql merge=ours
lunatrace/bsl/backend/schema.graphql merge=ours
lunatrace/bsl/frontend/public/css/**/* merge=ours
lunatrace/bsl/frontend/src/api/generated.ts merge=ours
lunatrace/bsl/backend/src/asura-api/generated.ts merge=ours
```
It will be gitignored.

On your machine, run 
`git config --global merge.ours.driver true`
before merging this to master.

I'm curious if this will eventually cause issues.  