### PR TITLE
add migration for cascading an organization removal

### DIFF
--- a/lunatrace/bsl/hasura/metadata/databases/lunatrace/tables/public_identities.yaml
+++ b/lunatrace/bsl/hasura/metadata/databases/lunatrace/tables/public_identities.yaml
@@ -16,6 +16,13 @@ array_relationships:
       table:
         name: identity_verifiable_addresses
         schema: public
+- name: users
+  using:
+    foreign_key_constraint_on:
+      column: kratos_id
+      table:
+        name: users
+        schema: public
 select_permissions:
 - permission:
     columns:

--- a/lunatrace/bsl/hasura/migrations/lunatrace/1649717845749_create-users-table-use-as-auth-table/up.sql
+++ b/lunatrace/bsl/hasura/migrations/lunatrace/1649717845749_create-users-table-use-as-auth-table/up.sql
@@ -20,3 +20,10 @@ ALTER TABLE public.organization_user ADD CONSTRAINT organization_user_user_id_fk
   FOREIGN KEY (user_id)
   REFERENCES public.users
   (id) ON UPDATE cascade ON DELETE cascade;
+
+UPDATE users SET github_id = (
+  SELECT kratos.github_id
+  FROM (
+    SELECT config->'providers'->0->>'subject' as github_id, identity_id FROM identity_credentials JOIN identities ON identities.id = identity_credentials.identity_id
+  ) as kratos WHERE users.kratos_id = kratos.identity_id AND kratos.github_id IS NOT NULL
+)

--- a/lunatrace/bsl/hasura/migrations/lunatrace/1650071188169_cascade-organization-related-information-on-delete/down.sql
+++ b/lunatrace/bsl/hasura/migrations/lunatrace/1650071188169_cascade-organization-related-information-on-delete/down.sql
@@ -1,0 +1,36 @@
+
+ALTER TABLE "public"."findings" DROP CONSTRAINT "findings_build_id_fkey",
+  ADD CONSTRAINT "findings_build_id_fkey"
+  FOREIGN KEY ("build_id")
+  REFERENCES "public"."builds"
+  ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+ALTER TABLE "public"."findings" DROP CONSTRAINT "findings_scan_id_fkey",
+  ADD CONSTRAINT "findings_scan_id_fkey"
+  FOREIGN KEY ("scan_id")
+  REFERENCES "public"."scans"
+  ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+ALTER TABLE "public"."scans" DROP CONSTRAINT "scans_build_id_fkey",
+  ADD CONSTRAINT "scans_build_id_fkey"
+  FOREIGN KEY ("build_id")
+  REFERENCES "public"."builds"
+  ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+ALTER TABLE "public"."manifests" DROP CONSTRAINT "manifests_build_id_fkey",
+  ADD CONSTRAINT "manifests_build_id_fkey"
+  FOREIGN KEY ("build_id")
+  REFERENCES "public"."builds"
+  ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+ALTER TABLE "public"."manifests" DROP CONSTRAINT "manifests_project_id_fkey",
+  ADD CONSTRAINT "manifests_project_id_fkey"
+  FOREIGN KEY ("project_id")
+  REFERENCES "public"."projects"
+  ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+ALTER TABLE "public"."builds" DROP CONSTRAINT "builds_project_id_fkey",
+  ADD CONSTRAINT "builds_project_id_fkey"
+  FOREIGN KEY ("project_id")
+  REFERENCES "public"."projects"
+  ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;

--- a/lunatrace/bsl/hasura/migrations/lunatrace/1650071188169_cascade-organization-related-information-on-delete/up.sql
+++ b/lunatrace/bsl/hasura/migrations/lunatrace/1650071188169_cascade-organization-related-information-on-delete/up.sql
@@ -1,0 +1,36 @@
+
+ALTER TABLE "public"."builds" DROP CONSTRAINT "builds_project_id_fkey",
+  ADD CONSTRAINT "builds_project_id_fkey"
+  FOREIGN KEY ("project_id")
+  REFERENCES "public"."projects"
+  ("id") ON UPDATE CASCADE ON DELETE CASCADE;
+
+ALTER TABLE "public"."manifests" DROP CONSTRAINT "manifests_project_id_fkey",
+  ADD CONSTRAINT "manifests_project_id_fkey"
+  FOREIGN KEY ("project_id")
+  REFERENCES "public"."projects"
+  ("id") ON UPDATE CASCADE ON DELETE CASCADE;
+
+ALTER TABLE "public"."manifests" DROP CONSTRAINT "manifests_build_id_fkey",
+  ADD CONSTRAINT "manifests_build_id_fkey"
+  FOREIGN KEY ("build_id")
+  REFERENCES "public"."builds"
+  ("id") ON UPDATE CASCADE ON DELETE CASCADE;
+
+ALTER TABLE "public"."scans" DROP CONSTRAINT "scans_build_id_fkey",
+  ADD CONSTRAINT "scans_build_id_fkey"
+  FOREIGN KEY ("build_id")
+  REFERENCES "public"."builds"
+  ("id") ON UPDATE CASCADE ON DELETE CASCADE;
+
+ALTER TABLE "public"."findings" DROP CONSTRAINT "findings_scan_id_fkey",
+  ADD CONSTRAINT "findings_scan_id_fkey"
+  FOREIGN KEY ("scan_id")
+  REFERENCES "public"."scans"
+  ("id") ON UPDATE CASCADE ON DELETE CASCADE;
+
+ALTER TABLE "public"."findings" DROP CONSTRAINT "findings_build_id_fkey",
+  ADD CONSTRAINT "findings_build_id_fkey"
+  FOREIGN KEY ("build_id")
+  REFERENCES "public"."builds"
+  ("id") ON UPDATE CASCADE ON DELETE CASCADE;


### PR DESCRIPTION
Removing an organization does not currently work because foreign keys are blocking its removal. 

Cascading was the chosen method for removing the related objects as an organization being deleted from LunaTrace should result in all of their associated data being removed.