### PR TITLE
Install fixes: Add node-gyp and lock engines to node v16

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,7 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/lunatrace/bsl/frontend/src/scss/proprietary-theme" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/tools/license-checker/skywalking-eyes" vcs="Git" />
   </component>
 </project>

--- a/.pnp.loader.mjs
+++ b/.pnp.loader.mjs
@@ -1,19 +1,3 @@
-/*
- * Copyright 2022 by LunaSec (owned by Refinery Labs, Inc)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
 import { URL, fileURLToPath, pathToFileURL } from 'url';
 import fs from 'fs';
 import path from 'path';

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "monorepo:version": "yarn node -p 'require(\"./lerna.json\").version'"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": "^16.0.0"
   },
   "version": "1.0.0",
   "workspaces": {
@@ -113,6 +113,7 @@
   },
   "packageManager": "yarn@3.1.1",
   "dependencies": {
-    "jest-environment-jsdom": "~28.0.2"
+    "jest-environment-jsdom": "~28.0.2",
+    "node-gyp": "~9.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -37009,6 +37009,7 @@ __metadata:
     js-yaml: ^4.1.0
     lerna: ^4.0.0
     lint-staged: ^12.1.2
+    node-gyp: ~9.0.0
     prettier: ^2.5.0
     rimraf: ^3.0.2
     tslint-config-prettier: ^1.18.0
@@ -38839,7 +38840,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp@npm:latest":
+"node-gyp@npm:latest, node-gyp@npm:~9.0.0":
   version: 9.0.0
   resolution: "node-gyp@npm:9.0.0"
   dependencies:


### PR DESCRIPTION
Adds `node-gyp` as a dependency of the root workspace so that modules that modules without prebuilt binaries can be built and avoid
```
Usage Error: Couldn't find a script name "node-gyp" in the top-level (used by deasync@npm:0.1.24). This typically happens because some package depends on "node-gyp" to build itself, but didn't list it in their dependencies. To fix that, please run "yarn add node-gyp" into your top-level workspace. You also can open an issue on the repository of the specified package to suggest them to use an optional peer dependency.
```

Pins `engines` to `^16` because `deasync` won't build against node v17. Ask me how I found out.