### PR TITLE
Changes for bringing up frontend docs

### DIFF
--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="JavaScriptLibraryMappings">
-    <file url="file://$PROJECT_DIR$" libraries="{Dependencies from js/internal-infrastructure/metrics-server-backend/package.json}" />
-  </component>
-</project>

--- a/lunatrace/README.md
+++ b/lunatrace/README.md
@@ -19,25 +19,9 @@ analysis at build time with runtime tracking and the capability to automatically
 ## Development
 Hasura manages the GraphQl API and postgres database, found in the `./hasura` folder.
 
-### Using the Database
-To use PSQL console or for connecting other services to the db, use the connection string found in the docker-compose.yaml file,
-under the key `PG_DATABASE_URL`
+See `README_DEV_SETUP.md` for info on bringing up Hasura and Ory.
 
-#### Migrating the Database
-The database must be migrated before the app can run.  First, make sure the database is running by doing `sudo docker-compose up`.
-Install kratos CLI according to the docs: https://www.ory.sh/docs/kratos/install
-Migrate Kratos:
-```bash 
-cd bsl/ory/kratos
-export DSN='postgres://postgres:postgrespassword@localhost:5431/lunatrace'
-kratos -c config.yaml migrate sql -e --yes    
-```
-Now migrate hasura which depends on the tables created by kratos. Make sure kratos is running as part of the docker-compose
-```bash
-cd bsl/hasura
-hasura metadata apply
-hasura migrate apply
-```
+
 Do **not** use the Hasura "console" GUI for managing the database, either creating tables or modifying them.  Hasura produces
 low quality up migrations and broken down migrations that are not maintainable.  For pre-production, modify the existing init migration files.
 For production migration, use `hasura migrate create <name>` to scaffold manual migrations.

--- a/lunatrace/README_DEV_SETUP.md
+++ b/lunatrace/README_DEV_SETUP.md
@@ -56,9 +56,9 @@ npm install -g smee-client
 
 ### Setup AWS Dependencies
 
-From `$REPO_ROOT/lunatrace/bsl/backend-cdk` folder, you'll need to run the following:
+From `$REPO_ROOT/lunatrace/bsl/backend-cdk` folder, you'll need to run the following. Replace YOUR_USERNAME with your user.
 ```sh
-DEV_USER=breadchris yarn run dev:cdk:deploy
+DEV_USER=YOUR_USERNAME yarn run dev:cdk:deploy
 ```
 
 That will run a real AWS deployment of the "dev" resources required. Once it finished, you should see something like:

--- a/lunatrace/README_DEV_SETUP.md
+++ b/lunatrace/README_DEV_SETUP.md
@@ -145,6 +145,15 @@ Those should work and pull up the whole DB. Once that's done you should be able 
 by running `hasura console` or going to `http://localhost:9695/`. This will show you the GraphQL server and an admin
 dashboard for the database.
 
+#### Frontend
+
+To set up the frontend, pull the theme submodule and compile the CSS:
+```sh
+cd bsl/frontend
+yarn run sass:pull
+yarn run sass:build
+```
+
 ### Re-run everything
 
 Either kill everything in tmuxp or just restart the front-end and back-end containers after Hasura comes up.

--- a/lunatrace/README_DEV_SETUP.md
+++ b/lunatrace/README_DEV_SETUP.md
@@ -58,7 +58,7 @@ npm install -g smee-client
 
 From `$REPO_ROOT/lunatrace/bsl/backend-cdk` folder, you'll need to run the following:
 ```sh
-DEVELOPMENT=true yarn run cdk deploy
+DEV_USER=breadchris yarn run dev:cdk:deploy
 ```
 
 That will run a real AWS deployment of the "dev" resources required. Once it finished, you should see something like:
@@ -68,14 +68,14 @@ That will run a real AWS deployment of the "dev" resources required. Once it fin
 
 ✨  Deployment time: 180.43s
 
-Outputs:
-lunatrace-EtlStorage.ManifestBucketName = lunatrace-etlstorage-manifestbucket56c4asdf-5sxtasdfk1cv
-lunatrace-EtlStorage.ProcessManifestProcessingQueueName = lunatrace-EtlStorage-ProcessManifestProcessingQueue5A5F1DB3-ZP13rw2kLjIf
-lunatrace-EtlStorage.ProcessSbomProcessingQueueName = lunatrace-EtlStorage-ProcessSbomProcessingQueueA1A1FE19-EGIEef9a3zq8
-lunatrace-EtlStorage.SbomBucketName = lunatrace-etlstorage-sbombucket9670fef1-6yj5oftmc61vq
-
+lunatrace-alex-EtlStorage.ManifestBucketName = lunatrace-alex-etlstorage-manifestbucket46c412a5-1b0kc5cys81er
+lunatrace-alex-EtlStorage.ProcessManifestProcessingQueueName = lunatrace-alex-EtlStorage-ProcessManifestProcessingQueue7A1F1CB2-BWVszydikZnB
+lunatrace-alex-EtlStorage.ProcessRepositoryProcessingQueueName = lunatrace-alex-EtlStorage-ProcessRepositoryProcessingQueueD69CAAE0-ma9VglOAlgiF
+lunatrace-alex-EtlStorage.ProcessSbomProcessingQueueName = lunatrace-alex-EtlStorage-ProcessSbomProcessingQueueA3A9FE69-6CG55qoQkM7q
+lunatrace-alex-EtlStorage.ProcessWebhookProcessingQueueName = lunatrace-alex-EtlStorage-ProcessWebhookProcessingQueue475F8047-ZzRXj42PsJAZ
+lunatrace-alex-EtlStorage.SbomBucketName = lunatrace-alex-etlstorage-sbombucket8550fee8-1drqtwb7yf2dg
 Stack ARN:
-arn:aws:cloudformation:us-west-2:1234567890:stack/lunatrace-EtlStorage/asdf5ee5-cd11-22ec-82c9-5264031fasdf
+arn:aws:cloudformation:us-west-2:134071937287:stack/lunatrace-alex-EtlStorage/4655a320-cb37-11ec-a2b1-02772921f86f
 
 ✨  Total time: 184.84s
 ```
@@ -83,10 +83,12 @@ arn:aws:cloudformation:us-west-2:1234567890:stack/lunatrace-EtlStorage/asdf5ee5-
 You'll need to format those values into an env file at `$REPO/lunatrace/dev-cli/.env.dev` that looks like:
 
 ```env
-S3_MANIFEST_BUCKET="lunatrace-etlstorage-manifestbucket56c4asdf-5sxtasdfk1cv"
-PROCESS_MANIFEST_QUEUE="lunatrace-EtlStorage-ProcessManifestProcessingQueue5A5F1DB3-ZP13rw2kLjIf"
-PROCESS_SBOM_QUEUE="lunatrace-EtlStorage-ProcessSbomProcessingQueueA1A1FE19-EGIEef9a3zq8"
-S3_SBOM_BUCKET="lunatrace-etlstorage-sbombucket9670fef1-6yj5oftmc61vq"
+S3_SBOM_BUCKET=lunatrace-alex-etlstorage-sbombucket8550fee8-1drqtwb7yf2dg
+S3_MANIFEST_BUCKET=lunatrace-alex-etlstorage-manifestbucket46c412a5-1b0kc5cys81er
+PROCESS_WEBHOOK_QUEUE=lunatrace-alex-EtlStorage-ProcessWebhookProcessingQueue475F8047-ZzRXj42PsJAZ
+PROCESS_REPOSITORY_QUEUE=lunatrace-alex-EtlStorage-ProcessRepositoryProcessingQueueD69CAAE0-ma9VglOAlgiF
+PROCESS_MANIFEST_QUEUE=lunatrace-alex-EtlStorage-ProcessManifestProcessingQueue7A1F1CB2-BWVszydikZnB
+PROCESS_SBOM_QUEUE=lunatrace-alex-EtlStorage-ProcessSbomProcessingQueueA3A9FE69-6CG55qoQkM7q
 ```
 
 ### Running `tmuxp`
@@ -118,7 +120,8 @@ We use Hasura and Kratos, so there will be a few incantations required to make t
 #### Kratos (do this first):
 
 ```sh
-sudo docker exec -it $(sudo docker ps | grep kratos | awk '{print $1}') /usr/bin/kratos migrate sql /config/config.yaml migrate sql -e --yes
+cd bsl
+sudo docker-compose exec kratos /usr/bin/kratos migrate sql /config/config.yaml migrate sql -e --yes
 ```
 
 That's a bit of a magical command but... it's basically just finding the Kratos Docker container ID and then running the
@@ -129,12 +132,13 @@ will ensure that your Kratos version is always in sync with the Docker version._
 
 #### Hasura (second):
 
-From the `bsl/hasura` folder run...
+Run...
 
 ```sh
-hasura migrate apply
+cd bsl/hasura
 hasura metadata apply
 hasura metadata reload
+hasura migrate apply
 ```
 
 Those should work and pull up the whole DB. Once that's done you should be able to pull up the Hasura console either

--- a/lunatrace/bsl/docker-compose.yaml
+++ b/lunatrace/bsl/docker-compose.yaml
@@ -58,6 +58,7 @@ services:
     - db_data:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: postgrespassword
+      POSTGRES_DB: lunatrace
   graphql-engine:
     image: hasura/graphql-engine:v2.2.2
     ports:

--- a/lunatrace/bsl/hasura/migrations/lunatrace/1649717845749_create-users-table-use-as-auth-table/up.sql
+++ b/lunatrace/bsl/hasura/migrations/lunatrace/1649717845749_create-users-table-use-as-auth-table/up.sql
@@ -21,9 +21,9 @@ ALTER TABLE public.organization_user ADD CONSTRAINT organization_user_user_id_fk
   REFERENCES public.users
   (id) ON UPDATE cascade ON DELETE cascade;
 
-UPDATE users SET github_id = (
+UPDATE public.users SET github_id = (
   SELECT kratos.github_id
   FROM (
-    SELECT config->'providers'->0->>'subject' as github_id, identity_id FROM identity_credentials JOIN identities ON identities.id = identity_credentials.identity_id
-  ) as kratos WHERE users.kratos_id = kratos.identity_id AND kratos.github_id IS NOT NULL
-)
+    SELECT config->'providers'->0->>'subject' as github_id, identity_id FROM public.identity_credentials JOIN public.identities ON public.identities.id = public.identity_credentials.identity_id
+  ) as kratos WHERE public.users.kratos_id = kratos.identity_id AND kratos.github_id IS NOT NULL
+);

--- a/lunatrace/bsl/hasura/migrations/lunatrace/1650321911749_add_webhook_cache/up.sql
+++ b/lunatrace/bsl/hasura/migrations/lunatrace/1650321911749_add_webhook_cache/up.sql
@@ -1,4 +1,4 @@
-CREATE TYPE github_webhook_event AS ENUM (
+CREATE TYPE public.github_webhook_event AS ENUM (
  'branch_protection_rule',
  'check_run',
  'check_suite',
@@ -49,9 +49,9 @@ CREATE TYPE github_webhook_event AS ENUM (
  'unknown'
 );
 
-CREATE TABLE webhook_cache(
+CREATE TABLE public.webhook_cache(
   delivery_id UUID PRIMARY KEY NOT NULL,
-  event_type github_webhook_event NOT NULL,
+  event_type public.github_webhook_event NOT NULL,
   created_at timestamp NOT NULL DEFAULT NOW(),
   signature_256 TEXT NOT NULL,
   installation_id INTEGER,
@@ -59,6 +59,6 @@ CREATE TABLE webhook_cache(
   sqs_message_id TEXT
 );
 
-CREATE INDEX webhook_cache_created_at_idx ON webhook_cache(created_at);
-CREATE INDEX webhook_cache_event_type_idx ON webhook_cache(event_type);
-CREATE INDEX webhook_cache_sqs_message_id_idx ON webhook_cache(sqs_message_id);
+CREATE INDEX webhook_cache_created_at_idx ON public.webhook_cache(created_at);
+CREATE INDEX webhook_cache_event_type_idx ON public.webhook_cache(event_type);
+CREATE INDEX webhook_cache_sqs_message_id_idx ON public.webhook_cache(sqs_message_id);


### PR DESCRIPTION
* Updates guide for bringing up frontend.
* Removes duplicated instructions in README.md, replaced with a pointer to README_DEV_SETUP.md
* Adds POSTGRES_DB env var to docker compose to create `lunasec` db on startup, this is required before bootstrapping ory/hasura.
* Replaced docker ps grep oneliner with docker compose equivelant.
* Added env vars that were missing

Borrowed some sql migrations from mac bring up diff.