### PR TITLE
Fix back button on login

### DIFF
--- a/.idea/runConfigurations/LunaTrace_Frontend.xml
+++ b/.idea/runConfigurations/LunaTrace_Frontend.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="LunaTrace Frontend" type="JavascriptDebugType" uri="http://localhost:4455" useFirstLineBreakpoints="true">
+    <method v="2" />
+  </configuration>
+</component>

--- a/lunatrace/bsl/frontend/src/routes.tsx
+++ b/lunatrace/bsl/frontend/src/routes.tsx
@@ -13,6 +13,7 @@
  */
 import React from 'react';
 import { RouteObject } from 'react-router';
+import { Navigate } from 'react-router-dom';
 
 import { RouteGuard } from './components/auth/RouteGuard';
 import MainLayout from './layouts/Main';
@@ -91,6 +92,12 @@ export const routes: RouteObject[] = [
         ],
       },
       { path: 'auth', children: [{ path: 'error', element: <AuthError /> }] },
+      // Login is handled by auth service, but we can still get here if the user hits back. Send those users back to
+      // the homepage.
+      {
+        path: 'login',
+        element: <Navigate to={'/'} />,
+      },
       {
         element: <p>404</p>, //doesnt work
       },


### PR DESCRIPTION
When hitting back from the login page, the user is sent to `/login` on the react app, which is unhandled.

Adds a route for `/login` which redirects the user to the homepage. This doesn't affect the normal auth flow because `/login` is supposed to be handled by the auth service.

Adds a debugging config for frontend that starts up Chrome pointed at the existing dev instance.