### PR TITLE
Report status during install

### DIFF
--- a/lunatrace/bsl/backend/src/github/api/generated.ts
+++ b/lunatrace/bsl/backend/src/github/api/generated.ts
@@ -24019,7 +24019,7 @@ export type GetMembersForOrganizationQueryVariables = Exact<{
 }>;
 
 
-export type GetMembersForOrganizationQuery = { __typename?: 'Query', organization?: { __typename?: 'Organization', id: string, login: string, teams: { __typename?: 'TeamConnection', nodes?: Array<{ __typename?: 'Team', members: { __typename?: 'TeamMemberConnection', nodes?: Array<{ __typename?: 'User', name?: string | null, id: string } | null> | null, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, startCursor?: string | null } } } | null> | null, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, startCursor?: string | null } }, membersWithRole: { __typename?: 'OrganizationMemberConnection', nodes?: Array<{ __typename?: 'User', name?: string | null, id: string } | null> | null, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null, startCursor?: string | null } } } | null };
+export type GetMembersForOrganizationQuery = { __typename?: 'Query', organization?: { __typename?: 'Organization', id: string, login: string, teams: { __typename?: 'TeamConnection', nodes?: Array<{ __typename?: 'Team', members: { __typename?: 'TeamMemberConnection', nodes?: Array<{ __typename?: 'User', name?: string | null, databaseId?: number | null, id: string } | null> | null, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, startCursor?: string | null } } } | null> | null, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, startCursor?: string | null } }, membersWithRole: { __typename?: 'OrganizationMemberConnection', nodes?: Array<{ __typename?: 'User', name?: string | null, databaseId?: number | null, id: string } | null> | null, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null, startCursor?: string | null } } } | null };
 
 export type GetRepositoryQueryVariables = Exact<{
   name: Scalars['String'];
@@ -24039,7 +24039,7 @@ export type GetUserOrganizationsQuery = { __typename?: 'Query', viewer: { __type
 export type GetViewerIdQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetViewerIdQuery = { __typename?: 'Query', viewer: { __typename?: 'User', id: string } };
+export type GetViewerIdQuery = { __typename?: 'Query', viewer: { __typename?: 'User', id: string, databaseId?: number | null } };
 
 export type SubmitPrReviewMutationVariables = Exact<{
   pull_request_id: Scalars['ID'];
@@ -24085,6 +24085,7 @@ export const GetMembersForOrganizationDocument = gql`
         members(first: 100, after: $after) {
           nodes {
             name
+            databaseId
             id
           }
           pageInfo {
@@ -24103,6 +24104,7 @@ export const GetMembersForOrganizationDocument = gql`
     membersWithRole(first: 100, after: $after) {
       nodes {
         name
+        databaseId
         id
       }
       pageInfo {
@@ -24147,6 +24149,7 @@ export const GetViewerIdDocument = gql`
     query GetViewerId {
   viewer {
     id
+    databaseId
   }
 }
     `;

--- a/lunatrace/bsl/backend/src/github/install.ts
+++ b/lunatrace/bsl/backend/src/github/install.ts
@@ -36,13 +36,18 @@ async function waitForGithubInstall(installationId: number): Promise<MaybeErrorV
   const maxAttempts = 10;
 
   while (attempts < maxAttempts) {
-    const installedProjects = await hasura.GetProjectsForInstallationId({
+    const projectCountQuery = await hasura.GetProjectCountForInstallation({
       installation_id: installationId,
     });
 
-    const projects = installedProjects.organizations.flatMap((o) => o.projects);
+    const count = projectCountQuery.projects_aggregate.aggregate?.count;
 
-    if (projects.length > 0) {
+    if (count === undefined) {
+      return newError(
+        'Unable to verify Github App was installed successfully. Contact support if this problem persists.'
+      );
+    }
+    if (count > 0) {
       break;
     }
     await sleep(1000);

--- a/lunatrace/bsl/backend/src/github/install.ts
+++ b/lunatrace/bsl/backend/src/github/install.ts
@@ -11,16 +11,50 @@
  * limitations under the License.
  *
  */
+import * as querystring from 'querystring';
+
 import { Request, Response } from 'express';
 
 import { getServerConfig } from '../config';
-import { errorResponse } from '../utils/errors';
+import { hasura } from '../hasura-api';
+import { MaybeErrorVoid } from '../types/util';
+import { errorResponse, newError, newResult } from '../utils/errors';
 import { log } from '../utils/log';
 import { tryParseInt } from '../utils/parse';
+import { sleep } from '../utils/sleep';
 
 import { getInstallationAccessToken } from './auth';
 
 const serverConfig = getServerConfig();
+
+async function waitForGithubInstall(installationId: number): Promise<MaybeErrorVoid> {
+  // Check to see if user has any projects installed
+  // TODO (cthompson) this is a simple check at the moment for the scenario where someone
+  // is performing their first install. For any updates to an install, we want to be smart with this check
+  // and make sure that the newly added repos have been installed correctly before moving on.
+  let attempts = 0;
+  const maxAttempts = 10;
+
+  while (attempts < maxAttempts) {
+    const installedProjects = await hasura.GetProjectsForInstallationId({
+      installation_id: installationId,
+    });
+
+    const projects = installedProjects.organizations.flatMap((o) => o.projects);
+
+    if (projects.length > 0) {
+      break;
+    }
+    await sleep(1000);
+    attempts += 1;
+  }
+  if (attempts === maxAttempts) {
+    return newError(
+      'Unable to verify Github App was installed successfully. Contact support if this problem persists.'
+    );
+  }
+  return newResult(undefined);
+}
 
 // All of this code just checks that we are properly authed, it's just a sanity check.
 // We handle all the installation tasks such as populating repos in the github webhook queue handler for `installation.created`
@@ -73,7 +107,20 @@ export async function githubInstall(req: Request, res: Response): Promise<void> 
     return;
   }
 
-  log.info('Github App was installed correctly', {
+  const installError = await waitForGithubInstall(installationId);
+
+  if (installError.error) {
+    log.error('unable to verify that Github App was installed successfully', {
+      installationId,
+    });
+    const errorMsg = querystring.stringify({
+      error: installError.msg,
+    });
+    res.status(302).redirect(serverConfig.sitePublicUrl + '?' + errorMsg);
+    return;
+  }
+
+  log.info('Github App was installed successfully', {
     installationId,
   });
 

--- a/lunatrace/bsl/backend/src/hasura-api/generated.ts
+++ b/lunatrace/bsl/backend/src/hasura-api/generated.ts
@@ -40,6 +40,11 @@ export type Scalars = {
   uuid: any;
 };
 
+export type AuthenticatedRepoCloneUrlOutput = {
+  __typename?: 'AuthenticatedRepoCloneUrlOutput';
+  url?: Maybe<Scalars['String']>;
+};
+
 /** Boolean expression to compare columns of type "Boolean". All fields are combined with logical 'AND'. */
 export type Boolean_Comparison_Exp = {
   _eq?: InputMaybe<Scalars['Boolean']>;
@@ -64,6 +69,20 @@ export type Int_Comparison_Exp = {
   _lte?: InputMaybe<Scalars['Int']>;
   _neq?: InputMaybe<Scalars['Int']>;
   _nin?: InputMaybe<Array<Scalars['Int']>>;
+};
+
+export type PresignedUrlResponse = {
+  __typename?: 'PresignedUrlResponse';
+  bucket: Scalars['String'];
+  headers: Scalars['jsonb'];
+  key: Scalars['String'];
+  url: Scalars['String'];
+};
+
+export type SbomUploadUrlOutput = {
+  __typename?: 'SbomUploadUrlOutput';
+  error: Scalars['Boolean'];
+  uploadUrl?: Maybe<UploadUrl>;
 };
 
 /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
@@ -99,6 +118,12 @@ export type String_Comparison_Exp = {
   _similar?: InputMaybe<Scalars['String']>;
 };
 
+export type UploadUrl = {
+  __typename?: 'UploadUrl';
+  headers: Scalars['jsonb'];
+  url: Scalars['String'];
+};
+
 /** Boolean expression to compare columns of type "_text". All fields are combined with logical 'AND'. */
 export type _Text_Comparison_Exp = {
   _eq?: InputMaybe<Scalars['_text']>;
@@ -132,6 +157,7 @@ export type Builds = {
   project_id?: Maybe<Scalars['uuid']>;
   pull_request_id?: Maybe<Scalars['String']>;
   s3_url?: Maybe<Scalars['String']>;
+  s3_url_signed?: Maybe<Scalars['String']>;
   /** An array relationship */
   scans: Array<Scans>;
   source_type: Scalars['builds_source_type'];
@@ -914,6 +940,7 @@ export type Fix_State_Enum_Comparison_Exp = {
 /** Metadata about a github repository and where to find it. */
 export type Github_Repositories = {
   __typename?: 'github_repositories';
+  authenticated_clone_url?: Maybe<AuthenticatedRepoCloneUrlOutput>;
   git_url: Scalars['String'];
   github_id?: Maybe<Scalars['Int']>;
   github_node_id?: Maybe<Scalars['String']>;
@@ -2114,6 +2141,8 @@ export type Mutation_Root = {
   insert_webhook_cache?: Maybe<Webhook_Cache_Mutation_Response>;
   /** insert a single row into the table: "webhook_cache" */
   insert_webhook_cache_one?: Maybe<Webhook_Cache>;
+  /**  get s3 presigned url for manifest upload, used only by the frontend  */
+  presignManifestUpload?: Maybe<PresignedUrlResponse>;
   /** update data of the table: "builds" */
   update_builds?: Maybe<Builds_Mutation_Response>;
   /** update single row of the table: "builds" */
@@ -2427,6 +2456,12 @@ export type Mutation_RootInsert_Webhook_CacheArgs = {
 export type Mutation_RootInsert_Webhook_Cache_OneArgs = {
   object: Webhook_Cache_Insert_Input;
   on_conflict?: InputMaybe<Webhook_Cache_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootPresignManifestUploadArgs = {
+  project_id: Scalars['uuid'];
 };
 
 
@@ -3660,12 +3695,14 @@ export enum Projects_Update_Column {
 
 export type Query_Root = {
   __typename?: 'query_root';
+  authenticatedRepoCloneUrl?: Maybe<AuthenticatedRepoCloneUrlOutput>;
   /** An array relationship */
   builds: Array<Builds>;
   /** An aggregate relationship */
   builds_aggregate: Builds_Aggregate;
   /** fetch data from the table: "builds" using primary key columns */
   builds_by_pk?: Maybe<Builds>;
+  fakeQueryToHackHasuraBeingABuggyMess?: Maybe<Scalars['String']>;
   /** An array relationship */
   findings: Array<Findings>;
   /** fetch data from the table: "findings" using primary key columns */
@@ -3710,6 +3747,8 @@ export type Query_Root = {
   package_versions: Array<Package_Versions>;
   /** fetch data from the table: "package_versions" using primary key columns */
   package_versions_by_pk?: Maybe<Package_Versions>;
+  /**  get s3 presigned url for manifest upload, used by the CLI  */
+  presignSbomUpload?: Maybe<SbomUploadUrlOutput>;
   /** An array relationship */
   project_access_tokens: Array<Project_Access_Tokens>;
   /** fetch data from the table: "project_access_tokens" using primary key columns */
@@ -3722,6 +3761,7 @@ export type Query_Root = {
   related_vulnerabilities: Array<Related_Vulnerabilities>;
   /** fetch data from the table: "related_vulnerabilities" using primary key columns */
   related_vulnerabilities_by_pk?: Maybe<Related_Vulnerabilities>;
+  sbomUrl?: Maybe<Scalars['String']>;
   /** An array relationship */
   scans: Array<Scans>;
   /** fetch data from the table: "scans" using primary key columns */
@@ -3748,6 +3788,11 @@ export type Query_Root = {
   webhook_cache: Array<Webhook_Cache>;
   /** fetch data from the table: "webhook_cache" using primary key columns */
   webhook_cache_by_pk?: Maybe<Webhook_Cache>;
+};
+
+
+export type Query_RootAuthenticatedRepoCloneUrlArgs = {
+  repoGithubId: Scalars['Int'];
 };
 
 
@@ -3932,6 +3977,12 @@ export type Query_RootPackage_Versions_By_PkArgs = {
 };
 
 
+export type Query_RootPresignSbomUploadArgs = {
+  buildId: Scalars['uuid'];
+  orgId: Scalars['uuid'];
+};
+
+
 export type Query_RootProject_Access_TokensArgs = {
   distinct_on?: InputMaybe<Array<Project_Access_Tokens_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -3971,6 +4022,11 @@ export type Query_RootRelated_VulnerabilitiesArgs = {
 
 export type Query_RootRelated_Vulnerabilities_By_PkArgs = {
   id: Scalars['uuid'];
+};
+
+
+export type Query_RootSbomUrlArgs = {
+  buildId: Scalars['uuid'];
 };
 
 
@@ -5748,6 +5804,13 @@ export type GetPreviousBuildForPrQueryVariables = Exact<{
 
 export type GetPreviousBuildForPrQuery = { __typename?: 'query_root', builds: Array<{ __typename?: 'builds', existing_github_review_id?: string | null }> };
 
+export type GetProjectsForInstallationIdQueryVariables = Exact<{
+  installation_id?: InputMaybe<Scalars['Int']>;
+}>;
+
+
+export type GetProjectsForInstallationIdQuery = { __typename?: 'query_root', organizations: Array<{ __typename?: 'organizations', projects: Array<{ __typename?: 'projects', github_repository?: { __typename?: 'github_repositories', github_id?: number | null } | null }> }> };
+
 export type GetUserRoleQueryVariables = Exact<{
   kratos_id?: InputMaybe<Scalars['uuid']>;
 }>;
@@ -5999,6 +6062,17 @@ export const GetPreviousBuildForPrDocument = gql`
     order_by: {created_at: desc}
   ) {
     existing_github_review_id
+  }
+}
+    `;
+export const GetProjectsForInstallationIdDocument = gql`
+    query GetProjectsForInstallationId($installation_id: Int) {
+  organizations(where: {installation_id: {_eq: $installation_id}}) {
+    projects {
+      github_repository {
+        github_id
+      }
+    }
   }
 }
     `;
@@ -6265,6 +6339,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     GetPreviousBuildForPr(variables: GetPreviousBuildForPrQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetPreviousBuildForPrQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetPreviousBuildForPrQuery>(GetPreviousBuildForPrDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetPreviousBuildForPr', 'query');
+    },
+    GetProjectsForInstallationId(variables?: GetProjectsForInstallationIdQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetProjectsForInstallationIdQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetProjectsForInstallationIdQuery>(GetProjectsForInstallationIdDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetProjectsForInstallationId', 'query');
     },
     GetUserRole(variables?: GetUserRoleQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetUserRoleQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetUserRoleQuery>(GetUserRoleDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetUserRole', 'query');

--- a/lunatrace/bsl/backend/src/hasura-api/generated.ts
+++ b/lunatrace/bsl/backend/src/hasura-api/generated.ts
@@ -2907,6 +2907,8 @@ export type Organizations = {
   organization_users: Array<Organization_User>;
   /** An array relationship */
   projects: Array<Projects>;
+  /** An aggregate relationship */
+  projects_aggregate: Projects_Aggregate;
   /** An object relationship */
   settings: Settings;
   settings_id: Scalars['uuid'];
@@ -2925,6 +2927,16 @@ export type OrganizationsOrganization_UsersArgs = {
 
 /** columns and relationships of "organizations" */
 export type OrganizationsProjectsArgs = {
+  distinct_on?: InputMaybe<Array<Projects_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Projects_Order_By>>;
+  where?: InputMaybe<Projects_Bool_Exp>;
+};
+
+
+/** columns and relationships of "organizations" */
+export type OrganizationsProjects_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Projects_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
@@ -3525,6 +3537,28 @@ export type ProjectsReportsArgs = {
   where?: InputMaybe<Project_Access_Tokens_Bool_Exp>;
 };
 
+/** aggregated selection of "projects" */
+export type Projects_Aggregate = {
+  __typename?: 'projects_aggregate';
+  aggregate?: Maybe<Projects_Aggregate_Fields>;
+  nodes: Array<Projects>;
+};
+
+/** aggregate fields of "projects" */
+export type Projects_Aggregate_Fields = {
+  __typename?: 'projects_aggregate_fields';
+  count: Scalars['Int'];
+  max?: Maybe<Projects_Max_Fields>;
+  min?: Maybe<Projects_Min_Fields>;
+};
+
+
+/** aggregate fields of "projects" */
+export type Projects_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Projects_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']>;
+};
+
 /** order by aggregate values of table "projects" */
 export type Projects_Aggregate_Order_By = {
   count?: InputMaybe<Order_By>;
@@ -3584,6 +3618,17 @@ export type Projects_Insert_Input = {
   settings_id?: InputMaybe<Scalars['uuid']>;
 };
 
+/** aggregate max on columns */
+export type Projects_Max_Fields = {
+  __typename?: 'projects_max_fields';
+  created_at?: Maybe<Scalars['timestamp']>;
+  id?: Maybe<Scalars['uuid']>;
+  name?: Maybe<Scalars['String']>;
+  organization_id?: Maybe<Scalars['uuid']>;
+  repo?: Maybe<Scalars['String']>;
+  settings_id?: Maybe<Scalars['uuid']>;
+};
+
 /** order by max() on columns of table "projects" */
 export type Projects_Max_Order_By = {
   created_at?: InputMaybe<Order_By>;
@@ -3592,6 +3637,17 @@ export type Projects_Max_Order_By = {
   organization_id?: InputMaybe<Order_By>;
   repo?: InputMaybe<Order_By>;
   settings_id?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Projects_Min_Fields = {
+  __typename?: 'projects_min_fields';
+  created_at?: Maybe<Scalars['timestamp']>;
+  id?: Maybe<Scalars['uuid']>;
+  name?: Maybe<Scalars['String']>;
+  organization_id?: Maybe<Scalars['uuid']>;
+  repo?: Maybe<Scalars['String']>;
+  settings_id?: Maybe<Scalars['uuid']>;
 };
 
 /** order by min() on columns of table "projects" */
@@ -3755,6 +3811,8 @@ export type Query_Root = {
   project_access_tokens_by_pk?: Maybe<Project_Access_Tokens>;
   /** An array relationship */
   projects: Array<Projects>;
+  /** An aggregate relationship */
+  projects_aggregate: Projects_Aggregate;
   /** fetch data from the table: "projects" using primary key columns */
   projects_by_pk?: Maybe<Projects>;
   /** An array relationship */
@@ -3998,6 +4056,15 @@ export type Query_RootProject_Access_Tokens_By_PkArgs = {
 
 
 export type Query_RootProjectsArgs = {
+  distinct_on?: InputMaybe<Array<Projects_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Projects_Order_By>>;
+  where?: InputMaybe<Projects_Bool_Exp>;
+};
+
+
+export type Query_RootProjects_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Projects_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
@@ -4577,6 +4644,8 @@ export type Subscription_Root = {
   project_access_tokens_by_pk?: Maybe<Project_Access_Tokens>;
   /** An array relationship */
   projects: Array<Projects>;
+  /** An aggregate relationship */
+  projects_aggregate: Projects_Aggregate;
   /** fetch data from the table: "projects" using primary key columns */
   projects_by_pk?: Maybe<Projects>;
   /** An array relationship */
@@ -4808,6 +4877,15 @@ export type Subscription_RootProject_Access_Tokens_By_PkArgs = {
 
 
 export type Subscription_RootProjectsArgs = {
+  distinct_on?: InputMaybe<Array<Projects_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Projects_Order_By>>;
+  where?: InputMaybe<Projects_Bool_Exp>;
+};
+
+
+export type Subscription_RootProjects_AggregateArgs = {
   distinct_on?: InputMaybe<Array<Projects_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
@@ -5804,12 +5882,12 @@ export type GetPreviousBuildForPrQueryVariables = Exact<{
 
 export type GetPreviousBuildForPrQuery = { __typename?: 'query_root', builds: Array<{ __typename?: 'builds', existing_github_review_id?: string | null }> };
 
-export type GetProjectsForInstallationIdQueryVariables = Exact<{
-  installation_id?: InputMaybe<Scalars['Int']>;
+export type GetProjectCountForInstallationQueryVariables = Exact<{
+  installation_id: Scalars['Int'];
 }>;
 
 
-export type GetProjectsForInstallationIdQuery = { __typename?: 'query_root', organizations: Array<{ __typename?: 'organizations', projects: Array<{ __typename?: 'projects', github_repository?: { __typename?: 'github_repositories', github_id?: number | null } | null }> }> };
+export type GetProjectCountForInstallationQuery = { __typename?: 'query_root', projects_aggregate: { __typename?: 'projects_aggregate', aggregate?: { __typename?: 'projects_aggregate_fields', count: number } | null } };
 
 export type GetUserRoleQueryVariables = Exact<{
   kratos_id?: InputMaybe<Scalars['uuid']>;
@@ -6065,13 +6143,13 @@ export const GetPreviousBuildForPrDocument = gql`
   }
 }
     `;
-export const GetProjectsForInstallationIdDocument = gql`
-    query GetProjectsForInstallationId($installation_id: Int) {
-  organizations(where: {installation_id: {_eq: $installation_id}}) {
-    projects {
-      github_repository {
-        github_id
-      }
+export const GetProjectCountForInstallationDocument = gql`
+    query GetProjectCountForInstallation($installation_id: Int!) {
+  projects_aggregate(
+    where: {organization: {installation_id: {_eq: $installation_id}}}
+  ) {
+    aggregate {
+      count
     }
   }
 }
@@ -6340,8 +6418,8 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     GetPreviousBuildForPr(variables: GetPreviousBuildForPrQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetPreviousBuildForPrQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetPreviousBuildForPrQuery>(GetPreviousBuildForPrDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetPreviousBuildForPr', 'query');
     },
-    GetProjectsForInstallationId(variables?: GetProjectsForInstallationIdQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetProjectsForInstallationIdQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetProjectsForInstallationIdQuery>(GetProjectsForInstallationIdDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetProjectsForInstallationId', 'query');
+    GetProjectCountForInstallation(variables: GetProjectCountForInstallationQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetProjectCountForInstallationQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetProjectCountForInstallationQuery>(GetProjectCountForInstallationDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetProjectCountForInstallation', 'query');
     },
     GetUserRole(variables?: GetUserRoleQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetUserRoleQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetUserRoleQuery>(GetUserRoleDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetUserRole', 'query');

--- a/lunatrace/bsl/backend/src/hasura-api/graphql/get-projects-for-installation-id.graphql
+++ b/lunatrace/bsl/backend/src/hasura-api/graphql/get-projects-for-installation-id.graphql
@@ -1,0 +1,9 @@
+query GetProjectsForInstallationId($installation_id: Int) {
+  organizations(where: {installation_id: {_eq: $installation_id}}) {
+    projects {
+      github_repository {
+        github_id
+      }
+    }
+  }
+}

--- a/lunatrace/bsl/backend/src/hasura-api/graphql/get-projects-for-installation-id.graphql
+++ b/lunatrace/bsl/backend/src/hasura-api/graphql/get-projects-for-installation-id.graphql
@@ -1,9 +1,7 @@
-query GetProjectsForInstallationId($installation_id: Int) {
-  organizations(where: {installation_id: {_eq: $installation_id}}) {
-    projects {
-      github_repository {
-        github_id
-      }
+query GetProjectCountForInstallation($installation_id: Int!) {
+  projects_aggregate(where: {organization: {installation_id: {_eq: $installation_id}}}) {
+    aggregate {
+      count
     }
   }
 }

--- a/lunatrace/bsl/backend/src/utils/sleep.ts
+++ b/lunatrace/bsl/backend/src/utils/sleep.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright by LunaSec (owned by Refinery Labs, Inc)
+ *
+ * Licensed under the Business Source License v1.1
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * https://github.com/lunasec-io/lunasec/blob/master/licenses/BSL-LunaTrace.txt
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+export const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));

--- a/lunatrace/bsl/backend/src/workers/activities/snapshot-repository-activity.ts
+++ b/lunatrace/bsl/backend/src/workers/activities/snapshot-repository-activity.ts
@@ -54,6 +54,9 @@ export async function snapshotRepositoryActivity(req: SnapshotForRepositoryReque
           project_id: repoClone.projectId,
           pull_request_id: req.pullRequestId,
           source_type: req.sourceType,
+          git_hash: req.gitCommit,
+          git_branch: req.gitBranch,
+          git_remote: req.cloneUrl,
         },
       })
   );

--- a/lunatrace/bsl/frontend/src/contexts/LayoutContext.tsx
+++ b/lunatrace/bsl/frontend/src/contexts/LayoutContext.tsx
@@ -12,9 +12,12 @@
  *
  */
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 
 import { LAYOUT } from '../constants';
+import useAppDispatch from '../hooks/useAppDispatch';
 import useSettingsState from '../hooks/useSettingsState';
+import { add } from '../store/slices/alerts';
 
 const initialState = {
   layout: LAYOUT.FLUID,
@@ -27,6 +30,16 @@ const LayoutContext = React.createContext(initialState);
 
 function LayoutProvider({ children }: { children: React.ReactNode }) {
   const [layout, setLayout] = useSettingsState('layout', LAYOUT.FLUID);
+
+  const dispatch = useAppDispatch();
+  const { search } = useLocation();
+
+  const queryParams = React.useMemo(() => new URLSearchParams(search), [search]);
+  const error = queryParams.get('error');
+
+  if (error) {
+    dispatch(add({ message: error }));
+  }
 
   return (
     <LayoutContext.Provider

--- a/lunatrace/bsl/hasura/metadata/databases/lunatrace/tables/public_projects.yaml
+++ b/lunatrace/bsl/hasura/metadata/databases/lunatrace/tables/public_projects.yaml
@@ -109,6 +109,7 @@ select_permissions:
         - organization_id
         - settings_id
       filter: {}
+      allow_aggregations: true
   - role: user
     permission:
       columns:


### PR DESCRIPTION
When an install is performed, there is a possibility that a user is sent back to lunatrace after going to Github, but the projects have not been populated yet. If this is the case, then it will appear as if the app is broken.

Waiting for the install event to at the very least create the organization/projects in the database will improve UX during install.