### PR TITLE
Add hasura metadata to deployed container

### DIFF
--- a/lunatrace/bsl/backend-cdk/lib/lunatrace-backend-stack.ts
+++ b/lunatrace/bsl/backend-cdk/lib/lunatrace-backend-stack.ts
@@ -260,8 +260,12 @@ export class LunatraceBackendStack extends cdk.Stack {
       issuer: 'http://oathkeeper:4455/',
     };
 
+    const hasuraContainerImage = ContainerImage.fromAsset('../hasura', {
+      ...commonBuildProps,
+    });
+
     const hasura = taskDef.addContainer('HasuraContainer', {
-      image: ContainerImage.fromRegistry('hasura/graphql-engine:v2.2.0'),
+      image: hasuraContainerImage,
       portMappings: [{ containerPort: 8080 }],
       logging: LogDriver.awsLogs({
         streamPrefix: 'lunatrace-hasura',

--- a/lunatrace/bsl/docker-compose.yaml
+++ b/lunatrace/bsl/docker-compose.yaml
@@ -107,21 +107,23 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
-  datadog:
-    image: datadog/agent:latest
-    environment:
-     DD_LOGS_ENABLED: "true"
-     DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL: "true"
-     DD_CONTAINER_EXCLUDE_LOGS: "name:datadog-agent"
-    env_file:
-      - .env.dev
-    volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
-      - "/proc/:/host/proc/:ro"
-      - "/opt/datadog-agent/run:/opt/datadog-agent/run:rw"
-      - "/sys/fs/cgroup/:/host/sys/fs/cgroup:ro"
-      - "./backend/logs/:/logs/:rw"
-      - "./datadog/:/etc/datadog-agent/conf.d/lunatrace.d/:ro"
+#  We need better namespacing in datadog before we enable this again.
+#  Currently, it will log alongside production which gets quite noisy.
+#  datadog:
+#    image: datadog/agent:latest
+#    environment:
+#     DD_LOGS_ENABLED: "true"
+#     DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL: "true"
+#     DD_CONTAINER_EXCLUDE_LOGS: "name:datadog-agent"
+#    env_file:
+#      - .env.dev
+#    volumes:
+#      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+#      - "/proc/:/host/proc/:ro"
+#      - "/opt/datadog-agent/run:/opt/datadog-agent/run:rw"
+#      - "/sys/fs/cgroup/:/host/sys/fs/cgroup:ro"
+#      - "./backend/logs/:/logs/:rw"
+#      - "./datadog/:/etc/datadog-agent/conf.d/lunatrace.d/:ro"
 
   mailslurper:
     image: oryd/mailslurper:latest-smtps

--- a/lunatrace/bsl/hasura/Dockerfile
+++ b/lunatrace/bsl/hasura/Dockerfile
@@ -1,0 +1,5 @@
+FROM hasura/graphql-engine:v2.2.0
+
+ENV HASURA_GRAPHQL_METADATA_DIR /hasura/metadata
+
+COPY metadata/ /hasura/metadata

--- a/lunatrace/bsl/hasura/metadata/databases/lunatrace/tables/package_package.yaml
+++ b/lunatrace/bsl/hasura/metadata/databases/lunatrace/tables/package_package.yaml
@@ -4,7 +4,6 @@ table:
 configuration:
   custom_root_fields: {}
   custom_name: package
-  column_config: {}
   custom_column_names: {}
 array_relationships:
   - name: package_maintainers

--- a/lunatrace/bsl/hasura/metadata/databases/lunatrace/tables/public_organization_user.yaml
+++ b/lunatrace/bsl/hasura/metadata/databases/lunatrace/tables/public_organization_user.yaml
@@ -27,14 +27,16 @@ insert_permissions:
           - organization:
               creator_id:
                 _eq: X-Hasura-Real-User-Id
-          - organization:
-              organization_users:
+          - _exists:
+              _where:
                 _and:
-                  - user:
-                      kratos_id:
-                        _eq: X-Hasura-User-Id
+                  - id:
+                      _eq: X-Hasura-Real-User-Id
                   - role:
-                      _eq: admin
+                      _eq: lunatrace_admin
+              _table:
+                schema: public
+                name: users
       set:
         user_id: x-hasura-Real-User-Id
       columns:


### PR DESCRIPTION
The deployed hasura container will have the metadata embedded in it when deployed to production. This removes the requirement of running `hasura metadata apply`.