### PR TITLE
Do not show all orgs if user is admin

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -10,11 +10,6 @@
   <component name="ProjectType">
     <option name="id" value="jpab" />
   </component>
-  <component name="SwUserDefinedSpecifications">
-    <option name="specTypeByUrl">
-      <map />
-    </option>
-  </component>
   <component name="WebPackConfiguration">
     <option name="mode" value="DISABLED" />
   </component>

--- a/lunatrace/bsl/frontend/src/api/generated.ts
+++ b/lunatrace/bsl/frontend/src/api/generated.ts
@@ -4989,7 +4989,7 @@ export type GetSbomUrlQueryVariables = Exact<{
 export type GetSbomUrlQuery = { __typename?: 'query_root', builds_by_pk?: { __typename?: 'builds', s3_url_signed?: string | null } | null };
 
 export type GetSidebarInfoQueryVariables = Exact<{
-  users_filter?: InputMaybe<Users_Bool_Exp>;
+  kratos_id?: InputMaybe<Scalars['uuid']>;
 }>;
 
 
@@ -5455,7 +5455,7 @@ export const GetSbomUrlDocument = `
 }
     `;
 export const GetSidebarInfoDocument = `
-    query GetSidebarInfo($users_filter: users_bool_exp = {}) {
+    query GetSidebarInfo($kratos_id: uuid) {
   projects(order_by: {name: asc}) {
     name
     id
@@ -5465,7 +5465,10 @@ export const GetSidebarInfoDocument = `
       build_number
     }
   }
-  organizations(order_by: {projects_aggregate: {count: asc}}) {
+  organizations(
+    order_by: {projects_aggregate: {count: asc}}
+    where: {organization_users: {user: {kratos_id: {_eq: $kratos_id}}}}
+  ) {
     name
     id
     createdAt

--- a/lunatrace/bsl/frontend/src/api/graphql/getSidebarInfo.graphql
+++ b/lunatrace/bsl/frontend/src/api/graphql/getSidebarInfo.graphql
@@ -1,30 +1,28 @@
-query GetSidebarInfo($users_filter: users_bool_exp = {}) {
+query GetSidebarInfo($kratos_id: uuid) {
+  projects(order_by: {name: asc}) {
+    name
+    id
+    created_at
+    builds {
+      id
+      build_number
+    }
+  }
+  organizations(order_by: {projects_aggregate: {count: asc}}, where: {organization_users: {user: {kratos_id: {_eq: $kratos_id}}}}) {
+    name
+    id
+    createdAt
     projects(order_by: {name: asc}) {
-        name
+      name
+      id
+      created_at
+      github_repository {
         id
-        created_at
-
-        builds {
-            id
-            build_number
-        }
-    }
-
-    organizations(order_by: {projects_aggregate: {count: asc}}) {
-        name
+      }
+      builds {
         id
-        createdAt
-        projects(order_by: {name: asc}) {
-            name
-            id
-            created_at
-            github_repository {
-                id
-            }
-            builds {
-                id
-                build_number
-            }
-        }
+        build_number
+      }
     }
+  }
 }

--- a/lunatrace/bsl/frontend/src/components/navbar/NavbarBreadcrumbs.tsx
+++ b/lunatrace/bsl/frontend/src/components/navbar/NavbarBreadcrumbs.tsx
@@ -23,6 +23,7 @@ import useBreadCrumbs, {
 
 import api from '../../api/';
 import { GetSidebarInfoQuery } from '../../api/generated';
+import { SidebarContext } from '../../contexts/SidebarContext';
 import { WizardOpenContext } from '../../contexts/WizardContext';
 
 type Project = GetSidebarInfoQuery['projects'][number];
@@ -42,11 +43,11 @@ const getCurrentProject = (projects: Project[], params: Params): Project | null 
 // TODO: it seems like it's possible to define these breadcrumbs in the route definitions, instead of in this file.  That would be cleaner
 const ProjectBreadCrumb: BreadcrumbComponentType = (crumbProps: BreadcrumbComponentProps) => {
   // Doing queries here is actually completely performant thanks to the cache system, no new queries will fire
-  const { data } = api.useGetSidebarInfoQuery();
-  if (!data) {
+  const { sidebarData } = useContext(SidebarContext);
+  if (!sidebarData) {
     return null;
   }
-  const projects = data.projects;
+  const projects = sidebarData.projects;
 
   if (projects.length === 0) {
     console.error('no projects were found');
@@ -62,11 +63,11 @@ const ProjectBreadCrumb: BreadcrumbComponentType = (crumbProps: BreadcrumbCompon
 };
 
 const BuildBreadCrumb: BreadcrumbComponentType = (crumbProps: BreadcrumbComponentProps) => {
-  const { data } = api.useGetSidebarInfoQuery();
-  if (!data) {
+  const { sidebarData } = useContext(SidebarContext);
+  if (!sidebarData) {
     return null;
   }
-  const projects = data.projects;
+  const projects = sidebarData.projects;
 
   if (projects.length === 0) {
     console.error('no projects were found');
@@ -103,11 +104,11 @@ const VulnBreadCrumb: BreadcrumbComponentType = (crumbProps: BreadcrumbComponent
 };
 
 const OrganizationBreadCrumb: BreadcrumbComponentType = (crumbProps: BreadcrumbComponentProps) => {
-  const { data } = api.useGetSidebarInfoQuery();
-  if (!data) {
+  const { sidebarData } = useContext(SidebarContext);
+  if (!sidebarData) {
     return null;
   }
-  const filteredOrg = data.organizations.find((o) => o.id === crumbProps.match.params.project_id);
+  const filteredOrg = sidebarData.organizations.find((o) => o.id === crumbProps.match.params.project_id);
   if (!filteredOrg) {
     console.error('breadcrumb couldnt find org');
     return null;

--- a/lunatrace/bsl/frontend/src/components/navbar/NavbarProjectSearch.tsx
+++ b/lunatrace/bsl/frontend/src/components/navbar/NavbarProjectSearch.tsx
@@ -11,19 +11,20 @@
  * limitations under the License.
  *
  */
-import React from 'react';
+import React, { useContext } from 'react';
 import { Button, Form, InputGroup } from 'react-bootstrap';
 import { Typeahead } from 'react-bootstrap-typeahead';
 import { Option } from 'react-bootstrap-typeahead/types/types';
 import { Search } from 'react-feather';
 import { useNavigate } from 'react-router-dom';
 
-import api from '../../api';
 import { GetSidebarInfoQuery } from '../../api/generated';
+import { SidebarContext } from '../../contexts/SidebarContext';
+
 export const ProjectSearch: React.FunctionComponent = () => {
   const navigate = useNavigate();
   // Just reuse the same query from the sidebar despite the overfetch, because it will be cached
-  const { data } = api.useGetSidebarInfoQuery();
+  const { sidebarData } = useContext(SidebarContext);
 
   const handleProjectSelected = (options: Option[]) => {
     const selected = options[0] as GetSidebarInfoQuery['projects'][number] | undefined;
@@ -41,7 +42,7 @@ export const ProjectSearch: React.FunctionComponent = () => {
           aria-label="Search Projects"
           onChange={handleProjectSelected}
           labelKey="name"
-          options={!data ? [] : data.projects}
+          options={!sidebarData ? [] : sidebarData.projects}
           highlightOnlyResult={true}
         />
         <Button variant="">

--- a/lunatrace/bsl/frontend/src/contexts/SidebarContext.tsx
+++ b/lunatrace/bsl/frontend/src/contexts/SidebarContext.tsx
@@ -11,12 +11,27 @@
  * limitations under the License.
  *
  */
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
+import api from '../api';
+import { GetSidebarInfoQuery } from '../api/generated';
 import { SIDEBAR_BEHAVIOR, SIDEBAR_POSITION } from '../constants';
+import useAppSelector from '../hooks/useAppSelector';
 import useSettingsState from '../hooks/useSettingsState';
+import { selectKratosId } from '../store/slices/authentication';
 
-const initialState = {
+interface SidebarContextType {
+  isOpen: boolean;
+  position: string;
+  behavior: string;
+  setIsOpen: (_a: boolean) => void;
+  setPosition: (_a: string) => void;
+  setBehavior: (_a: string) => void;
+  sidebarData: GetSidebarInfoQuery | undefined;
+  sidebarIsLoaded: boolean;
+}
+
+const initialState: SidebarContextType = {
   isOpen: false,
   position: SIDEBAR_POSITION.LEFT,
   behavior: SIDEBAR_BEHAVIOR.STICKY,
@@ -29,6 +44,8 @@ const initialState = {
   setBehavior: (_a: string) => {
     return;
   },
+  sidebarData: undefined,
+  sidebarIsLoaded: false,
 };
 
 const SidebarContext = React.createContext(initialState);
@@ -37,6 +54,18 @@ function SidebarProvider({ children }: { children: React.ReactNode }) {
   const [isOpen, setIsOpen] = useState(window.innerWidth > 992);
   const [position, setPosition] = useSettingsState('sidebarPosition', SIDEBAR_POSITION.LEFT);
   const [behavior, setBehavior] = useSettingsState('sidebarBehavior', SIDEBAR_BEHAVIOR.STICKY);
+
+  const kratosId = useAppSelector(selectKratosId);
+  const [trigger, result, lastPromiseInfo] = api.useLazyGetSidebarInfoQuery();
+  const { data, isLoading } = result;
+
+  useEffect(() => {
+    if (kratosId) {
+      void trigger({
+        kratos_id: kratosId,
+      });
+    }
+  }, [kratosId]);
 
   return (
     <SidebarContext.Provider
@@ -47,6 +76,8 @@ function SidebarProvider({ children }: { children: React.ReactNode }) {
         setPosition,
         behavior,
         setBehavior,
+        sidebarData: data,
+        sidebarIsLoaded: !isLoading && data !== undefined,
       }}
     >
       {children}

--- a/lunatrace/bsl/frontend/src/contexts/WizardContext.tsx
+++ b/lunatrace/bsl/frontend/src/contexts/WizardContext.tsx
@@ -11,30 +11,24 @@
  * limitations under the License.
  *
  */
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 
 import api from '../api';
 import useAppSelector from '../hooks/useAppSelector';
-import { selectIsAuthenticated } from '../store/slices/authentication';
+import { selectIsAuthenticated, selectKratosId } from '../store/slices/authentication';
 import { userHasAnyOrganizations } from '../utils/organizations';
+
+import { SidebarContext } from './SidebarContext';
 
 const defaultState = false;
 
 const WizardOpenContext = React.createContext(defaultState);
 
 function WizardOpenProvider({ children }: { children: React.ReactNode }) {
-  const [trigger, result, lastPromiseInfo] = api.useLazyGetSidebarInfoQuery();
-  const { data } = result;
-
+  const { sidebarData } = useContext(SidebarContext);
   const isAuthenticated = useAppSelector(selectIsAuthenticated);
 
-  useEffect(() => {
-    if (isAuthenticated) {
-      void trigger();
-    }
-  }, [isAuthenticated]);
-
-  const wizardOpen = isAuthenticated && !userHasAnyOrganizations(data);
+  const wizardOpen = isAuthenticated && !userHasAnyOrganizations(sidebarData);
 
   return <WizardOpenContext.Provider value={wizardOpen}>{children}</WizardOpenContext.Provider>;
 }

--- a/lunatrace/bsl/frontend/src/layouts/Main.tsx
+++ b/lunatrace/bsl/frontend/src/layouts/Main.tsx
@@ -13,16 +13,16 @@
  */
 
 import { AxiosError } from 'axios';
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 
-import api from '../api';
 import { AlertsHeader } from '../components/AlertsHeader';
 import Wrapper from '../components/Wrapper';
 import Navbar from '../components/navbar/Navbar';
 import { NavbarBreadcrumbs } from '../components/navbar/NavbarBreadcrumbs';
 import Sidebar from '../components/sidebar/Sidebar';
 import { generateSidebarItems } from '../components/sidebar/sidebarItems';
+import { SidebarContext } from '../contexts/SidebarContext';
 import useAppDispatch from '../hooks/useAppDispatch';
 import useAppSelector from '../hooks/useAppSelector';
 import { selectIsAuthenticated, setConfirmedUnauthenticated, setSession } from '../store/slices/authentication';
@@ -31,6 +31,8 @@ import oryClient from '../utils/ory-client';
 const MainLayout: React.FunctionComponent = (props) => {
   const dispatch = useAppDispatch();
   const isAuthenticated = useAppSelector(selectIsAuthenticated);
+  const { sidebarData } = useContext(SidebarContext);
+
   // TODO move this into its own context
   useEffect(() => {
     oryClient
@@ -59,19 +61,10 @@ const MainLayout: React.FunctionComponent = (props) => {
       });
   }, []);
 
-  const [trigger, result, lastPromiseInfo] = api.useLazyGetSidebarInfoQuery();
-  const { data } = result;
-
-  useEffect(() => {
-    if (isAuthenticated) {
-      void trigger();
-    }
-  }, [isAuthenticated]);
-
   return (
     <React.Fragment>
       <Wrapper>
-        <Sidebar sections={generateSidebarItems(data, isAuthenticated)} />
+        <Sidebar sections={generateSidebarItems(sidebarData, isAuthenticated)} />
         <div className="main">
           <Navbar />
 

--- a/lunatrace/bsl/frontend/src/pages/homepage/cards/RecentProjects.tsx
+++ b/lunatrace/bsl/frontend/src/pages/homepage/cards/RecentProjects.tsx
@@ -11,19 +11,19 @@
  * limitations under the License.
  *
  */
-import React from 'react';
+import React, { useContext } from 'react';
 import { Card, Modal } from 'react-bootstrap';
 import { AiFillFolderOpen } from 'react-icons/ai';
 import { NavLink } from 'react-router-dom';
 
-import api from '../../../api';
+import { SidebarContext } from '../../../contexts/SidebarContext';
 import { useRecentProjects } from '../../../hooks/useRecentProjects';
 
 export const RecentProjectsCard: React.FC = () => {
-  const { data } = api.useGetSidebarInfoQuery();
+  const { sidebarData } = useContext(SidebarContext);
   // Get some filler projects so we have something to show brand new users
   // will be replaced with real data once they start clicking projects
-  const fillerProjects = data?.projects.slice(0, 4) || [];
+  const fillerProjects = sidebarData?.projects.slice(0, 4) || [];
   const [recentProjects] = useRecentProjects(fillerProjects);
 
   return (

--- a/lunatrace/bsl/frontend/src/pages/project/Create.tsx
+++ b/lunatrace/bsl/frontend/src/pages/project/Create.tsx
@@ -11,7 +11,7 @@
  * limitations under the License.
  *
  */
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { Button, Card, Col, FloatingLabel, Form, Row, Spinner } from 'react-bootstrap';
 import { Helmet } from 'react-helmet-async';
 import { BiUnlink } from 'react-icons/bi';
@@ -24,6 +24,7 @@ import { GetSidebarInfoQuery } from '../../api/generated';
 import { SpinIfLoading } from '../../components/SpinIfLoading';
 import { ConditionallyRender } from '../../components/utils/ConditionallyRender';
 import { GithubAppUrl } from '../../constants';
+import { SidebarContext } from '../../contexts/SidebarContext';
 import useAppDispatch from '../../hooks/useAppDispatch';
 import { add } from '../../store/slices/alerts';
 
@@ -129,13 +130,13 @@ const ProjectCreateForm = ({ data }: { data: GetSidebarInfoQuery | undefined }) 
 };
 
 export const ProjectCreate: React.FC = () => {
-  const { data, isLoading } = api.useGetSidebarInfoQuery();
+  const { sidebarData, sidebarIsLoaded } = useContext(SidebarContext);
 
   return (
     <>
       <Helmet title={'Create Project'} />
-      <SpinIfLoading isLoading={isLoading}>
-        <ProjectCreateForm data={data} />
+      <SpinIfLoading isLoading={!sidebarIsLoaded}>
+        <ProjectCreateForm data={sidebarData} />
       </SpinIfLoading>
     </>
   );


### PR DESCRIPTION
All organizations were being shown in the sidebar if the user was admin. This will only show the organizations that the user is a user of. Using the admin page, more organizations can be joined.