### PR TITLE
resync all repos whenever any are updated

### DIFF
--- a/lunatrace/bsl/backend/src/github/webhooks/dispatcher.ts
+++ b/lunatrace/bsl/backend/src/github/webhooks/dispatcher.ts
@@ -34,6 +34,7 @@ export function registerWebhooksToInterceptor(interceptor: WebhookInterceptor): 
 
   listenToHook('installation_repositories.added', syncRepositoriesHandler);
   listenToHook('installation.created', syncRepositoriesHandler);
+  listenToHook('repository.edited', syncRepositoriesHandler); // Particularly inefficient over-fetching but...it does work
   listenToHook('pull_request', pullRequestHandler);
   listenToHook('organization.member_added', organizationMemberAddedHandler);
   listenToHook('push', pushHandler);

--- a/lunatrace/bsl/backend/src/github/webhooks/handlers/sync-repositories-handler.ts
+++ b/lunatrace/bsl/backend/src/github/webhooks/handlers/sync-repositories-handler.ts
@@ -20,9 +20,13 @@ import { getInstallationAccessToken } from '../../auth';
 // This simply calls github and upserts all repos.  We can call it in different situations where we thing the repos may have
 // Not the most performant solution but it works and is simple
 export async function syncRepositoriesHandler(
-  event: EmitterWebhookEvent<'installation_repositories.added' | 'installation.created'>
+  event: EmitterWebhookEvent<'installation_repositories.added' | 'installation.created' | 'repository.edited'>
 ) {
-  const installationId = event.payload.installation.id;
+  const installationId = event.payload.installation?.id;
+  if (!installationId) {
+    log.error('hook was missing installation id, exiting');
+    return;
+  }
   const installationAuthToken = await getInstallationAccessToken(installationId);
   if (installationAuthToken.error) {
     log.error('unable to get installation token', {

--- a/lunatrace/bsl/backend/src/github/webhooks/handlers/sync-repositories-handler.ts
+++ b/lunatrace/bsl/backend/src/github/webhooks/handlers/sync-repositories-handler.ts
@@ -24,7 +24,7 @@ export async function syncRepositoriesHandler(
 ) {
   const installationId = event.payload.installation?.id;
   if (!installationId) {
-    log.error('hook was missing installation id, exiting');
+    log.error('hook was missing installation id, aborting handler');
     return;
   }
   const installationAuthToken = await getInstallationAccessToken(installationId);


### PR DESCRIPTION
Fire the repository resync when we get a repository.edit webhook.  Did this particularly because it keeps the default_branch in sync, and it will keep anything else in sync also which is nice. 

It's an absolutely heinous overfetch but..it was certainly quick to write haha.  And realistically it's probably fine, its just a little speed-debt.