### PR TITLE
enable hasura query logging

### DIFF
--- a/lunatrace/bsl/backend-cdk/lib/lunatrace-backend-stack.ts
+++ b/lunatrace/bsl/backend-cdk/lib/lunatrace-backend-stack.ts
@@ -11,6 +11,7 @@
  * limitations under the License.
  *
  */
+ 
 import { inspect } from 'util';
 
 import { Certificate } from '@aws-cdk/aws-certificatemanager';

--- a/lunatrace/bsl/backend-cdk/lib/lunatrace-backend-stack.ts
+++ b/lunatrace/bsl/backend-cdk/lib/lunatrace-backend-stack.ts
@@ -281,6 +281,7 @@ export class LunatraceBackendStack extends cdk.Stack {
         HASURA_GRAPHQL_ENABLE_CONSOLE: 'true',
         HASURA_GRAPHQL_PG_CONNECTIONS: '100',
         HASURA_GRAPHQL_LOG_LEVEL: 'debug',
+        HASURA_GRAPHQL_ENABLED_LOG_TYPES: 'startup, http-log, webhook-log, websocket-log, query-log',
         HASURA_GRAPHQL_JWT_SECRET: JSON.stringify(hasuraJwtSecretValue),
         ACTION_BASE_URL: `http://localhost:${backend.containerPort}`,
         REMOTE_SCHEMA_URL: `http://localhost:${backend.containerPort}/graphql/v1`,

--- a/lunatrace/bsl/backend-cdk/lib/lunatrace-backend-stack.ts
+++ b/lunatrace/bsl/backend-cdk/lib/lunatrace-backend-stack.ts
@@ -11,7 +11,6 @@
  * limitations under the License.
  *
  */
-
 import { inspect } from 'util';
 
 import { Certificate } from '@aws-cdk/aws-certificatemanager';


### PR DESCRIPTION
Enables logging of hasura queries to datadog to avoid random timeouts. Will have to configure datadog to drop some of these fields because they are probably going to be too big.