### PR TITLE
No longer stringify context keys in JSON Logger transport

### DIFF
--- a/lunatrace/bsl/logger/src/index.ts
+++ b/lunatrace/bsl/logger/src/index.ts
@@ -145,7 +145,10 @@ export class LunaLogger {
       // If the argument is an object, then add its keys to the context object
       if (this.isObject(arg)) {
         const argAsObject = arg as object;
-        logObject.context = mergeObjectIntoRecord(logObject.context, argAsObject);
+        logObject.context = {
+          ...logObject.context,
+          ...argAsObject,
+        };
         return;
       }
 

--- a/lunatrace/bsl/logger/src/logio-transport.ts
+++ b/lunatrace/bsl/logger/src/logio-transport.ts
@@ -61,11 +61,12 @@ class LogIOClient {
 }
 
 function getSourceAndRemove(logObj: LogObj): string {
-  if (logObj.context.source) {
-    const source = logObj.context.source;
+  const logContextWithSource = logObj.context as { source?: string };
+  if (logContextWithSource.source) {
+    const source = logContextWithSource.source;
 
-    // remove source from context so it only gets logged in one place
-    delete logObj.context.source;
+    // remove source from context to ensure that it only gets logged in one place
+    delete logContextWithSource.source;
     return source;
   }
   return 'source';

--- a/lunatrace/bsl/logger/src/types.ts
+++ b/lunatrace/bsl/logger/src/types.ts
@@ -28,7 +28,7 @@ export interface LogObj {
   timePretty: string;
   name: string;
   message: string;
-  context: Record<string, string>;
+  context: object;
 }
 
 export interface Transport {


### PR DESCRIPTION
This makes logging in DataDog go from a "flat" stringified JSON object into a format that we can introspect to write alerts for.

I'm not exactly sure why this was implemented the way it was before, but from our testing this now works better for what we need (debugging production).