### PR TITLE
use smaller keys for lists in frontend

### DIFF
--- a/lunatrace/bsl/frontend/src/pages/project/builds/vulnerable-packages/body/TreeInfo.tsx
+++ b/lunatrace/bsl/frontend/src/pages/project/builds/vulnerable-packages/body/TreeInfo.tsx
@@ -78,10 +78,10 @@ export const TreeInfo: React.FunctionComponent<TreeInfoProps> = ({ pkg, depChain
           chainDedupeSlugs.push(dedupeSlug);
 
           return (
-            <div className="one-point-two-em d-flex pb-1 pt-1" key={JSON.stringify(chain)}>
+            <div className="one-point-two-em d-flex pb-1 pt-1" key={dedupeSlug}>
               {visibleChain.map((dep, index) => {
                 return (
-                  <React.Fragment key={JSON.stringify(dep)}>
+                  <React.Fragment key={dep.child_id}>
                     <div className="me-1 ms-1 d-inline-flex justify-content-center" style={{ flexDirection: 'column' }}>
                       {index !== 0 &&
                         (chain.length > visibleChain.length ? (


### PR DESCRIPTION
Fixes error by using smaller keys for lists
```
TreeInfo.tsx:81 Uncaught (in promise) RangeError: Invalid string length
    at JSON.stringify (<anonymous>)
    at TreeInfo.tsx:81:74
    at Array.map (<anonymous>)
    at QU (TreeInfo.tsx:72:16)
    at oo (react-dom.production.min.js:157:137)
    at Ks (react-dom.production.min.js:267:460)
    at Rl (react-dom.production.min.js:250:347)
    at Al (react-dom.production.min.js:250:278)
    at Tl (react-dom.production.min.js:250:138)
    at yl (react-dom.production.min.js:243:163)
```