### PR TITLE
Allow partial failure

### DIFF
--- a/lunatrace/bsl/backend/src/snapshot/node-package-tree.ts
+++ b/lunatrace/bsl/backend/src/snapshot/node-package-tree.ts
@@ -68,6 +68,7 @@ export async function collectPackageGraphsFromDirectory(repoDir: string): Promis
       } catch (e) {
         log.error('failed to parse a lockfile pair', {
           lockFilePathWithLeadingSlash,
+          e,
         });
         return {
           lockFilePath: lockFilePathWithLeadingSlash,


### PR DESCRIPTION
Allows failure of parsing of individual manifests within a repo.