### PR TITLE
Remove querying all builds to speed up performance

### DIFF
--- a/lunatrace/bsl/frontend/src/api/generated.ts
+++ b/lunatrace/bsl/frontend/src/api/generated.ts
@@ -6554,6 +6554,13 @@ export type GetBuildDetailsQueryVariables = Exact<{
 
 export type GetBuildDetailsQuery = { __typename?: 'query_root', builds_by_pk?: { __typename?: 'builds', build_number?: number | null, created_at: any, git_branch?: string | null, git_hash?: string | null, git_remote?: string | null, id: any, source_type: any, project_id?: any | null, resolved_manifests: Array<{ __typename?: 'resolved_manifest', id: any, path?: string | null, child_edges_recursive?: Array<{ __typename?: 'manifest_dependency_edge', parent_id: any, child_id: any, child: { __typename?: 'manifest_dependency_node', id: any, range: string, labels?: any | null, release_id: any, release: { __typename?: 'package_release', id: any, fetched_time?: any | null, version: string, package: { __typename?: 'package', name: string, last_successful_fetch?: any | null, package_manager: any, affected_by_vulnerability: Array<{ __typename?: 'vulnerability_affected', vulnerability: { __typename?: 'vulnerability', id: any, source_id: string, source: string }, ranges: Array<{ __typename?: 'vulnerability_range', introduced?: string | null, fixed?: string | null }> }> } } } }> | null }>, project?: { __typename?: 'projects', name: string, ignored_vulnerabilities: Array<{ __typename?: 'ignored_vulnerabilities', id: any, creator_id?: any | null, locations: any, note: string, project_id: any, vulnerability_id: any }> } | null, scans: Array<{ __typename?: 'scans', created_at: any, db_date: any, distro_name: string, distro_version: string, grype_version: string, id: any, scan_number?: number | null, source_type: string, target: string }>, scans_aggregate: { __typename?: 'scans_aggregate', aggregate?: { __typename?: 'scans_aggregate_fields', count: number } | null }, findings: Array<{ __typename?: 'findings', fix_state: any, fix_versions?: any | null, package_name: string, created_at: any, id: any, language: string, locations: any, matcher: string, purl: string, severity: any, type: string, version: string, updated_at: any, version_matcher: string, virtual_path?: string | null, vulnerability_id: any, vulnerability: { __typename?: 'vulnerability', id: any, summary?: string | null, source: string, source_id: string, cvss_score?: number | null, severities: Array<{ __typename?: 'vulnerability_severity', id: any, source: string, type: string, score: string }>, affected: Array<{ __typename?: 'vulnerability_affected', package: { __typename?: 'package', name: string, package_manager: any }, affected_range_events: Array<{ __typename?: 'vulnerability_affected_range_event', type: any, event: string, version: string }> }>, guide_vulnerabilities: Array<{ __typename?: 'guide_vulnerabilities', guide: { __typename?: 'guides', id: any, body: string, metadata: any, title: string, severity: any, summary: string, created_at: any, metadata_schema_version: number, related_guides: Array<{ __typename?: 'guide_related_guides', guide: { __typename?: 'guides', title: string, summary: string, id: any } }> } }>, ignored_vulnerabilities: Array<{ __typename?: 'ignored_vulnerabilities', creator_id?: any | null, id: any, locations: any, note: string, project_id: any, vulnerability_id: any }> } }> } | null };
 
+export type GetBuildNumberQueryVariables = Exact<{
+  build_id: Scalars['uuid'];
+}>;
+
+
+export type GetBuildNumberQuery = { __typename?: 'query_root', builds_by_pk?: { __typename?: 'builds', build_number?: number | null } | null };
+
 export type GetCurrentUserInfoQueryVariables = Exact<{
   kratos_id: Scalars['uuid'];
 }>;
@@ -6612,7 +6619,7 @@ export type GetSidebarInfoQueryVariables = Exact<{
 }>;
 
 
-export type GetSidebarInfoQuery = { __typename?: 'query_root', projects: Array<{ __typename?: 'projects', name: string, id: any, created_at: any, builds: Array<{ __typename?: 'builds', id: any, build_number?: number | null }> }>, organizations: Array<{ __typename?: 'organizations', name: string, id: any, createdAt: any, projects: Array<{ __typename?: 'projects', name: string, id: any, created_at: any, github_repository?: { __typename?: 'github_repositories', id: any } | null, builds: Array<{ __typename?: 'builds', id: any, build_number?: number | null }> }> }> };
+export type GetSidebarInfoQuery = { __typename?: 'query_root', projects: Array<{ __typename?: 'projects', name: string, id: any, created_at: any }>, organizations: Array<{ __typename?: 'organizations', name: string, id: any, createdAt: any, projects: Array<{ __typename?: 'projects', name: string, id: any, created_at: any, github_repository?: { __typename?: 'github_repositories', id: any } | null }> }> };
 
 export type SearchVulnerabilitiesQueryVariables = Exact<{
   search: Scalars['String'];
@@ -6858,6 +6865,13 @@ export const GetBuildDetailsDocument = `
         }
       }
     }
+  }
+}
+    `;
+export const GetBuildNumberDocument = `
+    query GetBuildNumber($build_id: uuid!) {
+  builds_by_pk(id: $build_id) {
+    build_number
   }
 }
     `;
@@ -7108,10 +7122,6 @@ export const GetSidebarInfoDocument = `
     name
     id
     created_at
-    builds {
-      id
-      build_number
-    }
   }
   organizations(
     order_by: {projects_aggregate: {count: asc}}
@@ -7126,10 +7136,6 @@ export const GetSidebarInfoDocument = `
       created_at
       github_repository {
         id
-      }
-      builds {
-        id
-        build_number
       }
     }
   }
@@ -7334,6 +7340,9 @@ const injectedRtkApi = api.injectEndpoints({
     }),
     GetBuildDetails: build.query<GetBuildDetailsQuery, GetBuildDetailsQueryVariables>({
       query: (variables) => ({ document: GetBuildDetailsDocument, variables })
+    }),
+    GetBuildNumber: build.query<GetBuildNumberQuery, GetBuildNumberQueryVariables>({
+      query: (variables) => ({ document: GetBuildNumberDocument, variables })
     }),
     GetCurrentUserInfo: build.query<GetCurrentUserInfoQuery, GetCurrentUserInfoQueryVariables>({
       query: (variables) => ({ document: GetCurrentUserInfoDocument, variables })

--- a/lunatrace/bsl/frontend/src/api/graphql/getBuildNumber.graphql
+++ b/lunatrace/bsl/frontend/src/api/graphql/getBuildNumber.graphql
@@ -1,0 +1,5 @@
+query GetBuildNumber($build_id: uuid!) {
+    builds_by_pk(id: $build_id) {
+        build_number
+    }
+}

--- a/lunatrace/bsl/frontend/src/api/graphql/getSidebarInfo.graphql
+++ b/lunatrace/bsl/frontend/src/api/graphql/getSidebarInfo.graphql
@@ -3,10 +3,6 @@ query GetSidebarInfo($kratos_id: uuid) {
     name
     id
     created_at
-    builds {
-      id
-      build_number
-    }
   }
   organizations(order_by: {projects_aggregate: {count: asc}}, where: {organization_users: {user: {kratos_id: {_eq: $kratos_id}}}}) {
     name
@@ -18,10 +14,6 @@ query GetSidebarInfo($kratos_id: uuid) {
       created_at
       github_repository {
         id
-      }
-      builds {
-        id
-        build_number
       }
     }
   }

--- a/lunatrace/bsl/frontend/src/api/index.ts
+++ b/lunatrace/bsl/frontend/src/api/index.ts
@@ -18,7 +18,7 @@ import { add } from '../store/slices/alerts';
 import { api as generatedApi } from './generated';
 // This extends the generated API so we can add any custom logic needed, as per https://www.graphql-code-generator.com/plugins/typescript-rtk-query
 const appApi = generatedApi.enhanceEndpoints({
-  addTagTypes: ['User', 'Projects', 'Organizations', 'Builds', 'ProjectDetails'],
+  addTagTypes: ['User', 'Projects', 'Organizations', 'Builds', 'BuildNumber', 'ProjectDetails'],
   endpoints: {
     GetSidebarInfo: {
       providesTags: ['Projects', 'Organizations'],
@@ -37,6 +37,9 @@ const appApi = generatedApi.enhanceEndpoints({
     },
     GetBuildDetails: {
       providesTags: ['Builds'],
+    },
+    GetBuildNumber: {
+      providesTags: ['BuildNumber'],
     },
     InsertPersonalProjectAndOrg: {
       invalidatesTags: ['Projects'],

--- a/lunatrace/bsl/frontend/src/api/index.ts
+++ b/lunatrace/bsl/frontend/src/api/index.ts
@@ -18,7 +18,7 @@ import { add } from '../store/slices/alerts';
 import { api as generatedApi } from './generated';
 // This extends the generated API so we can add any custom logic needed, as per https://www.graphql-code-generator.com/plugins/typescript-rtk-query
 const appApi = generatedApi.enhanceEndpoints({
-  addTagTypes: ['User', 'Projects', 'Organizations', 'Builds', 'BuildNumber', 'ProjectDetails'],
+  addTagTypes: ['User', 'Projects', 'Organizations', 'Builds', 'ProjectDetails'],
   endpoints: {
     GetSidebarInfo: {
       providesTags: ['Projects', 'Organizations'],
@@ -37,9 +37,6 @@ const appApi = generatedApi.enhanceEndpoints({
     },
     GetBuildDetails: {
       providesTags: ['Builds'],
-    },
-    GetBuildNumber: {
-      providesTags: ['BuildNumber'],
     },
     InsertPersonalProjectAndOrg: {
       invalidatesTags: ['Projects'],

--- a/lunatrace/bsl/frontend/src/components/navbar/NavbarBreadcrumbs.tsx
+++ b/lunatrace/bsl/frontend/src/components/navbar/NavbarBreadcrumbs.tsx
@@ -11,8 +11,8 @@
  * limitations under the License.
  *
  */
-import React, { useContext } from 'react';
-import { Breadcrumb } from 'react-bootstrap';
+import React, { useContext, useEffect } from 'react';
+import { Breadcrumb, Spinner } from 'react-bootstrap';
 import { NavLink, Params } from 'react-router-dom';
 import useBreadCrumbs, {
   BreadcrumbComponentProps,
@@ -63,25 +63,34 @@ const ProjectBreadCrumb: BreadcrumbComponentType = (crumbProps: BreadcrumbCompon
 };
 
 const BuildBreadCrumb: BreadcrumbComponentType = (crumbProps: BreadcrumbComponentProps) => {
-  const { sidebarData } = useContext(SidebarContext);
-  if (!sidebarData) {
-    return null;
-  }
-  const projects = sidebarData.projects;
+  const buildId = crumbProps.match.params.build_id;
 
-  if (projects.length === 0) {
-    console.error('no projects were found');
+  if (!buildId) {
     return null;
   }
 
-  const currentProject = getCurrentProject(projects, crumbProps.match.params);
-  if (currentProject === null) {
-    console.error('could not find current project');
-    return null;
+  const { data, isLoading } = api.useGetBuildNumberQuery({ build_id: buildId });
+
+  if (isLoading) {
+    return <Spinner size="sm" animation="border" />;
   }
 
-  const buildNumber = currentProject.builds.filter((b) => b.id === crumbProps.match.params.build_id)[0]?.build_number;
-  return <span># {buildNumber}</span>;
+  if (!data) {
+    console.error('Error loading build number', new Error('Error loading build number'));
+    return <span>Error loading build number</span>;
+  }
+
+  const buildsByPrimaryKey = data.builds_by_pk;
+
+  if (!buildsByPrimaryKey) {
+    console.error(
+      'Error, could not find build by primary key',
+      new Error('Error, could not find build by primary key')
+    );
+    return <span>Error: Unknown build</span>;
+  }
+
+  return <span># {buildsByPrimaryKey.build_number}</span>;
 };
 
 const BuildMainPathBreadCrumb: BreadcrumbComponentType = (crumbProps: BreadcrumbComponentProps) => {

--- a/lunatrace/bsl/frontend/src/components/navbar/NavbarBreadcrumbs.tsx
+++ b/lunatrace/bsl/frontend/src/components/navbar/NavbarBreadcrumbs.tsx
@@ -90,7 +90,7 @@ const BuildBreadCrumb: BreadcrumbComponentType = (crumbProps: BreadcrumbComponen
     return <span>Error: Unknown build</span>;
   }
 
-  return <span># {buildsByPrimaryKey.build_number}</span>;
+  return <span>#{buildsByPrimaryKey.build_number}</span>;
 };
 
 const BuildMainPathBreadCrumb: BreadcrumbComponentType = (crumbProps: BreadcrumbComponentProps) => {


### PR DESCRIPTION
Currently this adds about 10 seconds in production and slams the DB. This fixes that.