### PR TITLE
move rule to file

### DIFF
--- a/lunadefend/go/service/executor.go
+++ b/lunadefend/go/service/executor.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package service
 
 import (
@@ -68,11 +67,7 @@ func NewExecutorWithoutStreaming(
 	}
 }
 
-func NewExecutor(
-	command string,
-	args []string,
-	env map[string]string,
-) Executor {
+func NewExecutor(command string, args []string, env map[string]string, stdin io.Reader) Executor {
 	cwd, err := os.Getwd()
 	if err != nil {
 		panic(err)
@@ -82,7 +77,7 @@ func NewExecutor(
 		Args:    args,
 		Env:     env,
 		Cwd:     cwd,
-		Stdin:   nil,
+		Stdin:   stdin,
 
 		Shell:       false,
 		StreamStdio: false,

--- a/lunatrace/bsl/semgrep/cli/rules/importedandcalled.go
+++ b/lunatrace/bsl/semgrep/cli/rules/importedandcalled.go
@@ -1,6 +1,6 @@
 // Copyright by LunaSec (owned by Refinery Labs, Inc)
 //
-// Licensed under the Business Source License v1.1 
+// Licensed under the Business Source License v1.1
 // (the "License"); you may not use this file except in compliance with the
 // License. You may obtain a copy of the License at
 //
@@ -8,46 +8,16 @@
 //
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package rules
 
 import (
-	"github.com/rs/zerolog/log"
 	"os"
 	"text/template"
-)
 
-const ImportedAndCalledSemgrepRule = `
-rules:
-  - id: imported-and-called
-    options:
-      symbolic_propagation: true
-    patterns:
-      - pattern-either:
-          - pattern-inside: |
-              $IMPORT = require("{{ .PackageName }}")
-              ...
-          - pattern-inside: |
-              import $IMPORT from "{{ .PackageName }}"
-              ...
-          - pattern-inside: |
-              import * as $IMPORT from "{{ .PackageName }}"
-              ...
-          - pattern-inside: |
-              import { ..., $IMPORT,... } from "{{ .PackageName }}"
-              ...
-          - pattern-inside: |
-              import { ..., $X as $IMPORT,... } from "{{ .PackageName }}"
-              ...
-      - pattern-either:
-        - pattern-inside: $IMPORT.$FUNC()
-        - pattern-inside: $IMPORT()
-    message: A vulnerable package was imported and called.
-    languages:
-      - javascript
-      - typescript
-    severity: ERROR
-`
+	"github.com/rs/zerolog/log"
+
+	"github.com/lunasec-io/lunasec/lunatrace/bsl/semgrep/cli/rules/tpl"
+)
 
 type ImportedAndCalledSemgrepRuleVariables struct {
 	PackageName string
@@ -63,11 +33,7 @@ func CallsitesOfDependencyInCode(dependency, codeDir string) (bool, error) {
 	defer f.Close()
 	defer os.Remove(f.Name())
 
-	semgrepRuleTemplate, err := template.New("imported-and-called-semgrep-rule").Parse(ImportedAndCalledSemgrepRule)
-	if err != nil {
-		log.Error().Err(err).Msg("failed to parse semgrep rule")
-		return false, err
-	}
+	semgrepRuleTemplate, err := template.New("imported-and-called-semgrep-rule").ParseFS(tpl.RuleTemplates, "importedandcalled.yaml.tpl")
 
 	templateVariables := ImportedAndCalledSemgrepRuleVariables{
 		PackageName: dependency,

--- a/lunatrace/bsl/semgrep/cli/rules/importedandcalled.go
+++ b/lunatrace/bsl/semgrep/cli/rules/importedandcalled.go
@@ -34,6 +34,10 @@ func CallsitesOfDependencyInCode(dependency, codeDir string) (bool, error) {
 	defer os.Remove(f.Name())
 
 	semgrepRuleTemplate, err := template.New("imported-and-called-semgrep-rule").ParseFS(tpl.RuleTemplates, "importedandcalled.yaml.tpl")
+	if err != nil {
+		log.Error().Err(err).Msg("failed to parse semgrep rule")
+		return false, err
+	}
 
 	templateVariables := ImportedAndCalledSemgrepRuleVariables{
 		PackageName: dependency,

--- a/lunatrace/bsl/semgrep/cli/rules/semgrep.go
+++ b/lunatrace/bsl/semgrep/cli/rules/semgrep.go
@@ -1,6 +1,6 @@
 // Copyright by LunaSec (owned by Refinery Labs, Inc)
 //
-// Licensed under the Business Source License v1.1 
+// Licensed under the Business Source License v1.1
 // (the "License"); you may not use this file except in compliance with the
 // License. You may obtain a copy of the License at
 //
@@ -8,21 +8,23 @@
 //
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package rules
 
 import (
 	"encoding/json"
-	"github.com/lunasec-io/lunasec/lunadefend/go/service"
+	"io"
+
 	"github.com/rs/zerolog/log"
+
+	"github.com/lunasec-io/lunasec/lunadefend/go/service"
 )
 
-func runSemgrepRule(rule, dir string) (*SemgrepResults, error) {
+func runSemgrepRule(rule io.Reader, dir string) (*SemgrepResults, error) {
 	args := []string{
-		"--json", "-c", rule, dir,
+		"--json", "-c", "-", dir,
 	}
 
-	executor := service.NewExecutor("semgrep", args, map[string]string{})
+	executor := service.NewExecutor("semgrep", args, map[string]string{}, rule)
 
 	result, err := executor.Execute()
 	if err != nil {

--- a/lunatrace/bsl/semgrep/cli/rules/tpl/embed.go
+++ b/lunatrace/bsl/semgrep/cli/rules/tpl/embed.go
@@ -1,0 +1,21 @@
+// Copyright by LunaSec (owned by Refinery Labs, Inc)
+//
+// Licensed under the Business Source License v1.1 
+// (the "License"); you may not use this file except in compliance with the
+// License. You may obtain a copy of the License at
+//
+// https://github.com/lunasec-io/lunasec/blob/master/licenses/BSL-LunaTrace.txt
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package tpl
+
+import (
+	"embed"
+)
+
+// content is our static web server content.
+//
+//go:embed *
+var RuleTemplates embed.FS

--- a/lunatrace/bsl/semgrep/cli/rules/tpl/embed.go
+++ b/lunatrace/bsl/semgrep/cli/rules/tpl/embed.go
@@ -1,6 +1,6 @@
 // Copyright by LunaSec (owned by Refinery Labs, Inc)
 //
-// Licensed under the Business Source License v1.1 
+// Licensed under the Business Source License v1.1
 // (the "License"); you may not use this file except in compliance with the
 // License. You may obtain a copy of the License at
 //
@@ -8,14 +8,13 @@
 //
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package tpl
 
 import (
 	"embed"
 )
 
-// content is our static web server content.
+// embed all files in this directory to the module variable RuleTemplates
 //
 //go:embed *
 var RuleTemplates embed.FS

--- a/lunatrace/bsl/semgrep/cli/rules/tpl/importedandcalled.yaml.tpl
+++ b/lunatrace/bsl/semgrep/cli/rules/tpl/importedandcalled.yaml.tpl
@@ -1,0 +1,29 @@
+rules:
+  - id: imported-and-called
+    options:
+      symbolic_propagation: true
+    patterns:
+      - pattern-either:
+          - pattern-inside: |
+              $IMPORT = require("{{ .PackageName }}")
+              ...
+          - pattern-inside: |
+              import $IMPORT from "{{ .PackageName }}"
+              ...
+          - pattern-inside: |
+              import * as $IMPORT from "{{ .PackageName }}"
+              ...
+          - pattern-inside: |
+              import { ..., $IMPORT,... } from "{{ .PackageName }}"
+              ...
+          - pattern-inside: |
+              import { ..., $X as $IMPORT,... } from "{{ .PackageName }}"
+              ...
+      - pattern-either:
+        - pattern-inside: $IMPORT.$FUNC()
+        - pattern-inside: $IMPORT()
+    message: A vulnerable package was imported and called.
+    languages:
+      - javascript
+      - typescript
+    severity: ERROR


### PR DESCRIPTION
Moves semgrep rule to a separate file which is included by the build tooling with `embed`.

Reads the template directly from the embedded FS. Writes template to stdin of semgrep instead of tmpfile.