### PR TITLE
make logger params an object not an array

### DIFF
--- a/lunatrace/bsl/logger/src/index.ts
+++ b/lunatrace/bsl/logger/src/index.ts
@@ -137,6 +137,7 @@ export class LunaLogger {
       timeEpoch: now.getTime(),
       name: this.options.loggerName || defaultLoggerName,
       message: '',
+      params: {},
       context: {
         ...contextFromStorage,
         ...this.context,
@@ -155,9 +156,9 @@ export class LunaLogger {
       // If the item is the last in the list, then have no spacing.
       const spacing = index === args.length - 1 ? '' : ' ';
 
-      // If the argument is an object, then add its keys to the context object
+      // If the argument is an object, then add its keys to the params object
       if (this.isObject(arg)) {
-        logObject.params = [...(logObject.params || []), arg];
+        logObject.params = { ...logObject.params, ...arg };
 
         // Also log the error directly as a string
         if (arg instanceof Error) {
@@ -181,7 +182,7 @@ export class LunaLogger {
     });
   }
 
-  private isObject(arg: unknown): boolean {
+  private isObject(arg: unknown): arg is Record<string | number | symbol, unknown> {
     // sigh..ok javascript, if you say so
     return typeof arg === 'object' && !Array.isArray(arg) && arg !== null;
   }

--- a/lunatrace/bsl/logger/src/tests/logger.test.ts
+++ b/lunatrace/bsl/logger/src/tests/logger.test.ts
@@ -37,7 +37,7 @@ describe('LunaLogger', () => {
   it('appends any object properties from the first argument', () => {
     log.info({ test: 'field' });
     const output = consoleMock.mock.calls[0][0];
-    parseAndCheckParams(output, 0, 'test', 'field');
+    parseAndCheckParams(output, 'test', 'field');
   });
 
   it('stringifies anything else into message', () => {
@@ -117,7 +117,7 @@ function parseAndCheckContext(jsonString: string, key: string, value: unknown) {
   expect(parsed['context'][key]).toEqual(value);
 }
 
-function parseAndCheckParams(jsonString: string, index: number, key: string, value: unknown) {
+function parseAndCheckParams(jsonString: string, key: string | number | symbol, value: unknown) {
   const parsed = JSON.parse(jsonString); // This breaks if we use color, interestingly
-  expect(parsed['params'][index][key]).toEqual(value);
+  expect(parsed['params'][key]).toEqual(value);
 }

--- a/lunatrace/bsl/logger/src/types.ts
+++ b/lunatrace/bsl/logger/src/types.ts
@@ -28,8 +28,8 @@ export interface LogObj {
   timePretty: string;
   name: string;
   message: string;
-  context: object;
-  params?: unknown[];
+  context: Record<string | number | symbol, unknown>;
+  params: Record<string | number | symbol, unknown>;
   errors?: string[];
 }
 


### PR DESCRIPTION
makes data dog much better at filtering. Afaik its almost impossible to index by an array, and im not sure why we wanted this as an array at all. If theres a reason LMK