### PR TITLE
Tree rework

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -14,11 +14,6 @@
   <component name="ProjectType">
     <option name="id" value="jpab" />
   </component>
-  <component name="SwUserDefinedSpecifications">
-    <option name="specTypeByUrl">
-      <map />
-    </option>
-  </component>
   <component name="WebPackConfiguration">
     <option name="mode" value="DISABLED" />
   </component>

--- a/lunatrace/bsl/backend/src/fixtures/manifests/fake-dependency-tree-hasura-output-fixture.ts
+++ b/lunatrace/bsl/backend/src/fixtures/manifests/fake-dependency-tree-hasura-output-fixture.ts
@@ -11,10 +11,11 @@
  * limitations under the License.
  *
  */
-import { DependencyEdgePartial } from '../../models/dependency-tree/types';
+import { RawEdge } from '../../models/dependency-tree/types';
 
-export const fakeDependencyTreeHasuraOutputFixture: Array<DependencyEdgePartial> = [
+export const fakeDependencyTreeHasuraOutputFixture: Array<RawEdge> = [
   {
+    id: '1',
     child_id: '1',
     parent_id: '00000000-0000-0000-0000-000000000000',
     child: {
@@ -33,6 +34,8 @@ export const fakeDependencyTreeHasuraOutputFixture: Array<DependencyEdgePartial>
     },
   },
   {
+    id: '2',
+
     child_id: '2',
     parent_id: '1',
     child: {
@@ -51,6 +54,8 @@ export const fakeDependencyTreeHasuraOutputFixture: Array<DependencyEdgePartial>
     },
   },
   {
+    id: '3',
+
     child_id: '3',
     parent_id: '2',
     child: {
@@ -69,6 +74,8 @@ export const fakeDependencyTreeHasuraOutputFixture: Array<DependencyEdgePartial>
     },
   },
   {
+    id: '4',
+
     child_id: '4',
     parent_id: '3',
     child: {

--- a/lunatrace/bsl/backend/src/graphql-yoga/generated-resolver-types.ts
+++ b/lunatrace/bsl/backend/src/graphql-yoga/generated-resolver-types.ts
@@ -26,7 +26,7 @@ export type BuildData_AffectedByVulnerability = {
   __typename?: 'BuildData_AffectedByVulnerability';
   chains?: Maybe<Array<Array<BuildData_DependencyNode>>>;
   ranges?: Maybe<Array<Maybe<BuildData_Range>>>;
-  triviallyUpdatable?: Maybe<Scalars['Boolean']>;
+  trivially_updatable?: Maybe<Scalars['Boolean']>;
   vulnerability: BuildData_Vulnerability;
 };
 
@@ -69,13 +69,13 @@ export type BuildData_Vulnerability = {
 
 export type BuildData_VulnerableRelease = {
   __typename?: 'BuildData_VulnerableRelease';
-  affectedBy: Array<BuildData_AffectedByVulnerability>;
+  affected_by: Array<BuildData_AffectedByVulnerability>;
   chains: Array<Array<BuildData_DependencyNode>>;
   cvss?: Maybe<Scalars['Float']>;
-  devOnly: Scalars['Boolean'];
+  dev_only: Scalars['Boolean'];
   release?: Maybe<BuildData_Release>;
   severity?: Maybe<Scalars['String']>;
-  triviallyUpdatable: Scalars['String'];
+  trivially_updatable: Scalars['String'];
 };
 
 export type GithubRepository = {
@@ -314,7 +314,7 @@ export type AuthenticatedRepoCloneUrlOutputResolvers<ContextType = Context, Pare
 export type BuildData_AffectedByVulnerabilityResolvers<ContextType = Context, ParentType extends ResolversParentTypes['BuildData_AffectedByVulnerability'] = ResolversParentTypes['BuildData_AffectedByVulnerability']> = {
   chains?: Resolver<Maybe<Array<Array<ResolversTypes['BuildData_DependencyNode']>>>, ParentType, ContextType>;
   ranges?: Resolver<Maybe<Array<Maybe<ResolversTypes['BuildData_Range']>>>, ParentType, ContextType>;
-  triviallyUpdatable?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  trivially_updatable?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   vulnerability?: Resolver<ResolversTypes['BuildData_Vulnerability'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -357,13 +357,13 @@ export type BuildData_VulnerabilityResolvers<ContextType = Context, ParentType e
 };
 
 export type BuildData_VulnerableReleaseResolvers<ContextType = Context, ParentType extends ResolversParentTypes['BuildData_VulnerableRelease'] = ResolversParentTypes['BuildData_VulnerableRelease']> = {
-  affectedBy?: Resolver<Array<ResolversTypes['BuildData_AffectedByVulnerability']>, ParentType, ContextType>;
+  affected_by?: Resolver<Array<ResolversTypes['BuildData_AffectedByVulnerability']>, ParentType, ContextType>;
   chains?: Resolver<Array<Array<ResolversTypes['BuildData_DependencyNode']>>, ParentType, ContextType>;
   cvss?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
-  devOnly?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  dev_only?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   release?: Resolver<Maybe<ResolversTypes['BuildData_Release']>, ParentType, ContextType>;
   severity?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  triviallyUpdatable?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  trivially_updatable?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/lunatrace/bsl/backend/src/graphql-yoga/resolvers/vulnerable-releases-from-build.ts
+++ b/lunatrace/bsl/backend/src/graphql-yoga/resolvers/vulnerable-releases-from-build.ts
@@ -41,7 +41,7 @@ export const vulnerableReleasesFromBuildResolver: BuildVulnerabilitiesResolver =
     return null; // tells the client that we didnt get any tree info back and to fall back to grype (for now)
   }
 
-  const vulnerableReleases = depTree.getVulnerableReleases();
+  const vulnerableReleases = depTree.vulnerableReleases;
 
   const totalTime = Date.now() - startTime;
   log.info(`spent ${totalTime}ms processing tree`);
@@ -52,7 +52,7 @@ export const vulnerableReleasesFromBuildResolver: BuildVulnerabilitiesResolver =
 type ManifestData = NonNullable<NonNullable<GetTreeFromBuildQuery['builds_by_pk']>['resolved_manifests']>;
 type NodeData = NonNullable<ManifestData[number]['child_edges_recursive']>[number];
 
-export function buildTreeFromRawData<iManifestData>(rawManifestData: ManifestData): DependencyTree<NodeData> | null {
+export function buildTreeFromRawData<iManifestData>(rawManifestData: ManifestData): DependencyTree | null {
   if (!rawManifestData || rawManifestData.length === 0) {
     return null;
   }

--- a/lunatrace/bsl/backend/src/graphql-yoga/schema.graphql
+++ b/lunatrace/bsl/backend/src/graphql-yoga/schema.graphql
@@ -87,22 +87,21 @@ type OrgWithRepos {
 
 
 # ------- BEGIN VULNERABLE RELEASE RESPONSE TYPES BELOW, these reference the dependency-tree/types.ts
-# todo: awful mixing of camelcase and underscores here, need to fix the data to be all underscores
 type BuildData_VulnerableRelease {
-    devOnly: Boolean!
+    dev_only: Boolean!
     severity: String
     cvss: Float
     chains: [[BuildData_DependencyNode!]!]!
-    affectedBy: [BuildData_AffectedByVulnerability!]!
+    affected_by: [BuildData_AffectedByVulnerability!]!
     release: BuildData_Release
-    triviallyUpdatable: String!
+    trivially_updatable: String!
 }
 
 
 type BuildData_AffectedByVulnerability {
     vulnerability: BuildData_Vulnerability!
     ranges: [BuildData_Range]
-    triviallyUpdatable: Boolean
+    trivially_updatable: Boolean
     chains: [[BuildData_DependencyNode!]!] # each vuln has its own sublist of chains in addition to the global list in the main body of the release. This is in case some have been eliminated by false-positive analysis for only this vuln
 }
 

--- a/lunatrace/bsl/backend/src/hasura-api/generated.ts
+++ b/lunatrace/bsl/backend/src/hasura-api/generated.ts
@@ -31,6 +31,11 @@ export type Scalars = {
   uuid: string;
 };
 
+export type AuthenticatedRepoCloneUrlOutput = {
+  __typename?: 'AuthenticatedRepoCloneUrlOutput';
+  url?: Maybe<Scalars['String']>;
+};
+
 /** Boolean expression to compare columns of type "Boolean". All fields are combined with logical 'AND'. */
 export type Boolean_Comparison_Exp = {
   _eq?: InputMaybe<Scalars['Boolean']>;
@@ -42,6 +47,62 @@ export type Boolean_Comparison_Exp = {
   _lte?: InputMaybe<Scalars['Boolean']>;
   _neq?: InputMaybe<Scalars['Boolean']>;
   _nin?: InputMaybe<Array<Scalars['Boolean']>>;
+};
+
+export type BuildData_AffectedByVulnerability = {
+  __typename?: 'BuildData_AffectedByVulnerability';
+  chains?: Maybe<Array<Array<BuildData_DependencyNode>>>;
+  ranges?: Maybe<Array<Maybe<BuildData_Range>>>;
+  trivially_updatable?: Maybe<Scalars['Boolean']>;
+  vulnerability: BuildData_Vulnerability;
+};
+
+export type BuildData_DependencyNode = {
+  __typename?: 'BuildData_DependencyNode';
+  id: Scalars['String'];
+  range: Scalars['String'];
+  release: BuildData_Release;
+  release_id: Scalars['String'];
+};
+
+export type BuildData_Package = {
+  __typename?: 'BuildData_Package';
+  affected_by_vulnerability?: Maybe<Array<BuildData_AffectedByVulnerability>>;
+  name: Scalars['String'];
+  package_manager: Scalars['String'];
+};
+
+export type BuildData_Range = {
+  __typename?: 'BuildData_Range';
+  fixed?: Maybe<Scalars['String']>;
+  introduced?: Maybe<Scalars['String']>;
+};
+
+export type BuildData_Release = {
+  __typename?: 'BuildData_Release';
+  id: Scalars['String'];
+  package: BuildData_Package;
+  version: Scalars['String'];
+};
+
+export type BuildData_Vulnerability = {
+  __typename?: 'BuildData_Vulnerability';
+  cvss_score?: Maybe<Scalars['Float']>;
+  id: Scalars['String'];
+  severity_name?: Maybe<Scalars['String']>;
+  source: Scalars['String'];
+  source_id: Scalars['String'];
+};
+
+export type BuildData_VulnerableRelease = {
+  __typename?: 'BuildData_VulnerableRelease';
+  affected_by: Array<BuildData_AffectedByVulnerability>;
+  chains: Array<Array<BuildData_DependencyNode>>;
+  cvss?: Maybe<Scalars['Float']>;
+  dev_only: Scalars['Boolean'];
+  release?: Maybe<BuildData_Release>;
+  severity?: Maybe<Scalars['String']>;
+  trivially_updatable: Scalars['String'];
 };
 
 /** Boolean expression to compare columns of type "Float". All fields are combined with logical 'AND'. */
@@ -57,6 +118,25 @@ export type Float_Comparison_Exp = {
   _nin?: InputMaybe<Array<Scalars['Float']>>;
 };
 
+export type GithubRepository = {
+  __typename?: 'GithubRepository';
+  cloneUrl: Scalars['String'];
+  defaultBranch: Scalars['String'];
+  gitUrl: Scalars['String'];
+  orgId: Scalars['Int'];
+  orgName: Scalars['String'];
+  orgNodeId: Scalars['String'];
+  ownerType: Scalars['String'];
+  repoId: Scalars['Int'];
+  repoName: Scalars['String'];
+  repoNodeId: Scalars['String'];
+};
+
+export type InstallSelectedReposResponse = {
+  __typename?: 'InstallSelectedReposResponse';
+  success?: Maybe<Scalars['Boolean']>;
+};
+
 /** Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'. */
 export type Int_Comparison_Exp = {
   _eq?: InputMaybe<Scalars['Int']>;
@@ -68,6 +148,32 @@ export type Int_Comparison_Exp = {
   _lte?: InputMaybe<Scalars['Int']>;
   _neq?: InputMaybe<Scalars['Int']>;
   _nin?: InputMaybe<Array<Scalars['Int']>>;
+};
+
+export type OrgWithRepos = {
+  __typename?: 'OrgWithRepos';
+  id: Scalars['String'];
+  organizationName: Scalars['String'];
+  repos: Array<GithubRepository>;
+};
+
+export type OrgsWithReposInput = {
+  id: Scalars['String'];
+  repos: Array<Scalars['Int']>;
+};
+
+export type PresignedUrlResponse = {
+  __typename?: 'PresignedUrlResponse';
+  bucket: Scalars['String'];
+  headers: Scalars['jsonb'];
+  key: Scalars['String'];
+  url: Scalars['String'];
+};
+
+export type SbomUploadUrlOutput = {
+  __typename?: 'SbomUploadUrlOutput';
+  error: Scalars['Boolean'];
+  uploadUrl?: Maybe<UploadUrl>;
 };
 
 /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
@@ -101,6 +207,12 @@ export type String_Comparison_Exp = {
   _regex?: InputMaybe<Scalars['String']>;
   /** does the column match the given SQL regular expression */
   _similar?: InputMaybe<Scalars['String']>;
+};
+
+export type UploadUrl = {
+  __typename?: 'UploadUrl';
+  headers: Scalars['jsonb'];
+  url: Scalars['String'];
 };
 
 /** Boolean expression to compare columns of type "_text". All fields are combined with logical 'AND'. */
@@ -659,6 +771,7 @@ export type Builds = {
   /** An array relationship */
   resolved_manifests: Array<Resolved_Manifest>;
   s3_url?: Maybe<Scalars['String']>;
+  s3_url_signed?: Maybe<Scalars['String']>;
   /** An array relationship */
   scans: Array<Scans>;
   source_type: Scalars['builds_source_type'];
@@ -1709,6 +1822,7 @@ export type Fix_State_Enum_Comparison_Exp = {
 /** Metadata about a github repository and where to find it. */
 export type Github_Repositories = {
   __typename?: 'github_repositories';
+  authenticated_clone_url?: Maybe<AuthenticatedRepoCloneUrlOutput>;
   default_branch?: Maybe<Scalars['String']>;
   git_url: Scalars['String'];
   github_id?: Maybe<Scalars['Int']>;
@@ -3552,6 +3666,9 @@ export type Mutation_Root = {
   insert_webhook_cache?: Maybe<Webhook_Cache_Mutation_Response>;
   /** insert a single row into the table: "webhook_cache" */
   insert_webhook_cache_one?: Maybe<Webhook_Cache>;
+  installSelectedRepos?: Maybe<InstallSelectedReposResponse>;
+  /**  get s3 presigned url for manifest upload, used only by the frontend  */
+  presignManifestUpload?: Maybe<PresignedUrlResponse>;
   /** update data of the table: "analysis.manifest_dependency_edge_result" */
   update_analysis_manifest_dependency_edge_result?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Mutation_Response>;
   /** update single row of the table: "analysis.manifest_dependency_edge_result" */
@@ -4253,6 +4370,18 @@ export type Mutation_RootInsert_Webhook_CacheArgs = {
 export type Mutation_RootInsert_Webhook_Cache_OneArgs = {
   object: Webhook_Cache_Insert_Input;
   on_conflict?: InputMaybe<Webhook_Cache_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInstallSelectedReposArgs = {
+  orgs: Array<OrgsWithReposInput>;
+};
+
+
+/** mutation root */
+export type Mutation_RootPresignManifestUploadArgs = {
+  project_id: Scalars['uuid'];
 };
 
 
@@ -7018,6 +7147,8 @@ export type Query_Root = {
   analysis_manifest_dependency_edge_result: Array<Analysis_Manifest_Dependency_Edge_Result>;
   /** fetch data from the table: "analysis.manifest_dependency_edge_result" using primary key columns */
   analysis_manifest_dependency_edge_result_by_pk?: Maybe<Analysis_Manifest_Dependency_Edge_Result>;
+  authenticatedRepoCloneUrl?: Maybe<AuthenticatedRepoCloneUrlOutput>;
+  availableOrgsWithRepos?: Maybe<Array<OrgWithRepos>>;
   /** fetch data from the table: "build_dependency_relationship" */
   build_dependency_relationship: Array<Build_Dependency_Relationship>;
   /** fetch data from the table: "build_dependency_relationship" using primary key columns */
@@ -7034,6 +7165,7 @@ export type Query_Root = {
   builds_by_pk?: Maybe<Builds>;
   /** An array relationship */
   default_branch_builds: Array<Default_Branch_Builds>;
+  fakeQueryToHackHasuraBeingABuggyMess?: Maybe<Scalars['String']>;
   /** An array relationship */
   findings: Array<Findings>;
   /** fetch data from the table: "findings" using primary key columns */
@@ -7116,6 +7248,8 @@ export type Query_Root = {
   package_release_license: Array<Package_Release_License>;
   /** fetch data from the table: "package.release_license" using primary key columns */
   package_release_license_by_pk?: Maybe<Package_Release_License>;
+  /**  get s3 presigned url for manifest upload, used by the CLI  */
+  presignSbomUpload?: Maybe<SbomUploadUrlOutput>;
   /** An array relationship */
   project_access_tokens: Array<Project_Access_Tokens>;
   /** fetch data from the table: "project_access_tokens" using primary key columns */
@@ -7130,6 +7264,7 @@ export type Query_Root = {
   resolved_manifest: Array<Resolved_Manifest>;
   /** fetch data from the table: "resolved_manifest" using primary key columns */
   resolved_manifest_by_pk?: Maybe<Resolved_Manifest>;
+  sbomUrl?: Maybe<Scalars['String']>;
   /** An array relationship */
   scans: Array<Scans>;
   /** fetch data from the table: "scans" using primary key columns */
@@ -7176,6 +7311,7 @@ export type Query_Root = {
   vulnerability_severity: Array<Vulnerability_Severity>;
   /** fetch data from the table: "vulnerability.severity" using primary key columns */
   vulnerability_severity_by_pk?: Maybe<Vulnerability_Severity>;
+  vulnerableReleasesFromBuild?: Maybe<Array<BuildData_VulnerableRelease>>;
   /** fetch data from the table: "webhook_cache" */
   webhook_cache: Array<Webhook_Cache>;
   /** fetch data from the table: "webhook_cache" using primary key columns */
@@ -7194,6 +7330,11 @@ export type Query_RootAnalysis_Manifest_Dependency_Edge_ResultArgs = {
 
 export type Query_RootAnalysis_Manifest_Dependency_Edge_Result_By_PkArgs = {
   id: Scalars['uuid'];
+};
+
+
+export type Query_RootAuthenticatedRepoCloneUrlArgs = {
+  repoGithubId: Scalars['Int'];
 };
 
 
@@ -7554,6 +7695,12 @@ export type Query_RootPackage_Release_License_By_PkArgs = {
 };
 
 
+export type Query_RootPresignSbomUploadArgs = {
+  buildId: Scalars['uuid'];
+  orgId: Scalars['uuid'];
+};
+
+
 export type Query_RootProject_Access_TokensArgs = {
   distinct_on?: InputMaybe<Array<Project_Access_Tokens_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -7602,6 +7749,11 @@ export type Query_RootResolved_ManifestArgs = {
 
 export type Query_RootResolved_Manifest_By_PkArgs = {
   id: Scalars['uuid'];
+};
+
+
+export type Query_RootSbomUrlArgs = {
+  buildId: Scalars['uuid'];
 };
 
 
@@ -7765,6 +7917,11 @@ export type Query_RootVulnerability_SeverityArgs = {
 
 export type Query_RootVulnerability_Severity_By_PkArgs = {
   id: Scalars['uuid'];
+};
+
+
+export type Query_RootVulnerableReleasesFromBuildArgs = {
+  buildId: Scalars['uuid'];
 };
 
 

--- a/lunatrace/bsl/backend/src/hasura-api/generated.ts
+++ b/lunatrace/bsl/backend/src/hasura-api/generated.ts
@@ -11011,7 +11011,7 @@ export type GetTreeFromBuildQueryVariables = Exact<{
 }>;
 
 
-export type GetTreeFromBuildQuery = { __typename?: 'query_root', builds_by_pk?: { __typename?: 'builds', resolved_manifests: Array<{ __typename?: 'resolved_manifest', id: any, path?: string | null, child_edges_recursive?: Array<{ __typename?: 'manifest_dependency_edge', parent_id: any, child_id: any, child: { __typename?: 'manifest_dependency_node', id: any, range: string, labels?: any | null, release_id: any, release: { __typename?: 'package_release', id: any, fetched_time?: any | null, version: string, package: { __typename?: 'package', name: string, last_successful_fetch?: any | null, package_manager: any, affected_by_vulnerability: Array<{ __typename?: 'vulnerability_affected', vulnerability: { __typename?: 'vulnerability', id: any, source_id: string, source: string, severity_name?: any | null, cvss_score?: number | null }, ranges: Array<{ __typename?: 'vulnerability_range', introduced?: string | null, fixed?: string | null }> }> } } } }> | null }>, project?: { __typename?: 'projects', name: string, ignored_vulnerabilities: Array<{ __typename?: 'ignored_vulnerabilities', id: any, creator_id?: any | null, locations: any, note: string, project_id: any, vulnerability_id: any }> } | null } | null };
+export type GetTreeFromBuildQuery = { __typename?: 'query_root', builds_by_pk?: { __typename?: 'builds', resolved_manifests: Array<{ __typename?: 'resolved_manifest', id: any, path?: string | null, child_edges_recursive?: Array<{ __typename?: 'manifest_dependency_edge', parent_id: any, child_id: any, id: any, child: { __typename?: 'manifest_dependency_node', id: any, range: string, labels?: any | null, release_id: any, release: { __typename?: 'package_release', id: any, fetched_time?: any | null, version: string, package: { __typename?: 'package', name: string, last_successful_fetch?: any | null, package_manager: any, affected_by_vulnerability: Array<{ __typename?: 'vulnerability_affected', vulnerability: { __typename?: 'vulnerability', id: any, source_id: string, source: string, severity_name?: any | null, cvss_score?: number | null }, ranges: Array<{ __typename?: 'vulnerability_range', introduced?: string | null, fixed?: string | null }> }> } } } }> | null }>, project?: { __typename?: 'projects', name: string, ignored_vulnerabilities: Array<{ __typename?: 'ignored_vulnerabilities', id: any, creator_id?: any | null, locations: any, note: string, project_id: any, vulnerability_id: any }> } | null } | null };
 
 export type GetUserGitHubDataQueryVariables = Exact<{
   kratos_id?: InputMaybe<Scalars['uuid']>;
@@ -11375,6 +11375,7 @@ export const GetTreeFromBuildDocument = gql`
       child_edges_recursive {
         parent_id
         child_id
+        id
         child {
           id
           range

--- a/lunatrace/bsl/backend/src/hasura-api/graphql/get-tree-from-build.graphql
+++ b/lunatrace/bsl/backend/src/hasura-api/graphql/get-tree-from-build.graphql
@@ -8,6 +8,7 @@ query GetTreeFromBuild($build_id: uuid!) {
             child_edges_recursive {
                 parent_id
                 child_id
+                id
                 child {
                     id
                     range

--- a/lunatrace/bsl/backend/src/models/dependency-tree/builds-dependency-tree.ts
+++ b/lunatrace/bsl/backend/src/models/dependency-tree/builds-dependency-tree.ts
@@ -14,32 +14,45 @@
 import { severityOrderOsv } from '@lunatrace/lunatrace-common';
 import semver from 'semver';
 
-import { DependencyChain, DependencyEdgePartial, VulnerableRelease, VulnWithMetadata } from './types';
+import {
+  BuiltNode,
+  BuiltRelease,
+  BuiltVulnMeta,
+  DependencyChain,
+  RawEdge,
+  RawNode,
+  RawVulnMeta,
+  VulnerableRelease,
+} from './types';
 
-/**
- * @class DependencyTree
- */
-export class DependencyTree<DependencyEdge extends DependencyEdgePartial> {
+export class DependencyTree {
   // The following indexes are how the tree is "built". They allow high speed querying against the tree data without ever building a full tree in memory
+
+  // This is and should remain the only index that holds a reference to the actual nodes. All parsing algorithms must use this index to resolve depNodes
+  public depNodesById: Map<string, BuiltNode> = new Map();
+  // Used to trace the structure of the tree from the bottom up
   public nodeIdToParentIds: Map<string, Set<string>> = new Map();
-  public depNodesById: Map<string, DependencyEdge['child']> = new Map();
-  public vulnIdToVulns: Map<string, Set<VulnWithMetadata>> = new Map();
+  // Used so we can quickly fetch all nodes that are the same release (ex React@1.0.0)
   public depNodeIdsByReleaseId: Map<string, Set<string>> = new Map();
-  // public depNodeIdsByVulnerabilityId: Map<string, Set<string>> = new Map();
-  // public vulnerabilities: Array<AffectedByVulnerability>
+  // Holds which nodes have been determined to be vulnerable, for later processing
   public vulnerableDepNodeIds: Set<string> = new Set();
-  public vulnerableReleases: VulnerableRelease<DependencyEdgePartial>[];
-  // This builds the indexes and any useful data that show useful data about the tree
-  // Note that because we mostly extract information from the bottom of the tree upwards ( ex: show why a vulnerable package was installed)
-  constructor(sourceDeps: Array<DependencyEdge>) {
+  // This is the full computed dataset that we server directly to the frontend. This is the "output" format of the tree.
+  // Note that other public methods, like getVulnerabilities() rearrange this same data into different shapes for easier parsing outside of the tree
+  public vulnerableReleases: VulnerableRelease[];
+
+  // This constructor builds the indexes and any useful data that show useful data about the tree
+  constructor(sourceDeps: Array<RawEdge>) {
     // This is a hack to clone this object and unfreeze it, surprisingly tricky in JS
-    const flatEdges = JSON.parse(JSON.stringify(sourceDeps)) as Array<DependencyEdge>;
+    const flatEdges = JSON.parse(JSON.stringify(sourceDeps)) as Array<RawEdge>;
 
     flatEdges.forEach((edge) => {
-      // flatten the parent id into the child so we can forget about edges as much as possible
-      const depNode = edge.child;
-      depNode.parent_id = edge.parent_id;
-
+      // We modify some vulnerability data on the release and since that changes the whole type chain, we rebuild the release here
+      const builtRelease: BuiltRelease = {
+        ...edge.child.release,
+        package: { ...edge.child.release.package, affected_by_vulnerability: this.buildVulns(edge.child) },
+      };
+      // flatten the parent id into the child so we can forget about edges as much as possible, and filter the vulns
+      const depNode: BuiltNode = { ...edge.child, edge_id: edge.id, parent_id: edge.parent_id, release: builtRelease };
       // Create a map from a given release to the list of depNodes
       const existingNodesForThisRelease = this.depNodeIdsByReleaseId.get(depNode.release_id);
       if (existingNodesForThisRelease) {
@@ -57,41 +70,37 @@ export class DependencyTree<DependencyEdge extends DependencyEdgePartial> {
         this.nodeIdToParentIds.set(depNode.id, parentIdsToNode);
       }
 
-      // Create a separate lookup to directly map an ID to an edge
+      // Create a separate lookup to directly map an ID to a node
       this.depNodesById.set(depNode.id, depNode);
-
-      // TODO SEPERATE HERE, EVERYTHING BELOW IS COMPUTED OUTPUT DATA
-      // delete the vulnerabilities that don't apply because of semver
-      depNode.release.package.affected_by_vulnerability = depNode.release.package.affected_by_vulnerability.filter(
-        (vuln) => {
-          const vulnerableRange = this.convertRangesToSemverRange(vuln.ranges);
-          const isVulnerable = semver.satisfies(edge.child.release.version, vulnerableRange);
-
-          // Add to the lookup of vulns for later
-          if (isVulnerable) {
-            // Mark the vulns that can be trivially updated
-            vuln.triviallyUpdatable = this.precomputeVulnTriviallyUpdatable(edge.child.range, vuln);
-
-            const vulnSet = this.vulnIdToVulns.get(vuln.vulnerability.id) || new Set();
-            vulnSet.add(vuln);
-            this.vulnIdToVulns.set(vuln.vulnerability.id, vulnSet);
-            // mark this edge for later postprossesing when the tree is done being built
-            this.vulnerableDepNodeIds.add(depNode.id);
-          }
-
-          return isVulnerable;
-        }
-      );
     });
     this.vulnerableReleases = this.getVulnerableReleases();
   }
 
+  private buildVulns(depNode: RawNode): BuiltVulnMeta[] {
+    const builtVulns: BuiltVulnMeta[] = [];
+    depNode.release.package.affected_by_vulnerability.forEach((vuln) => {
+      const vulnerableRange = this.convertRangesToSemverRange(vuln.ranges);
+      const isVulnerable = semver.satisfies(depNode.release.version, vulnerableRange);
+
+      if (isVulnerable) {
+        // Add to the lookup of vulnerable deps for later
+        this.vulnerableDepNodeIds.add(depNode.id);
+        // Mark the vulns that can be trivially updated
+        const triviallyUpdatable = this.precomputeVulnTriviallyUpdatable(depNode.range, vuln);
+
+        const builtVuln: BuiltVulnMeta = { ...vuln, trivially_updatable: triviallyUpdatable, chains: [] };
+        builtVulns.push(builtVuln);
+      }
+    });
+    return builtVulns;
+  }
+
   // Calls getVulnerableReleases and changes the data shape to just be a list of vulns and their chains
-  public getVulnerabilities(): Array<VulnWithMetadata> {
-    const vulnsWithMetadata: Array<VulnWithMetadata> = [];
+  public getVulnerabilities(): Array<BuiltVulnMeta> {
+    const vulnsWithMetadata: Array<BuiltVulnMeta> = [];
 
     this.vulnerableReleases.forEach((release) => {
-      release.affectedBy.forEach((newVuln) => {
+      release.affected_by.forEach((newVuln) => {
         const existingVuln = vulnsWithMetadata.find((v) => v.vulnerability.id === newVuln.vulnerability.id);
         if (!existingVuln) {
           // its a new vuln, just add it to the list
@@ -100,7 +109,7 @@ export class DependencyTree<DependencyEdge extends DependencyEdgePartial> {
         }
         // just merge the vulnData into the main vuln
         existingVuln.chains = [...(existingVuln.chains || []), ...(newVuln.chains || [])];
-        existingVuln.triviallyUpdatable = existingVuln.triviallyUpdatable && newVuln.triviallyUpdatable;
+        existingVuln.trivially_updatable = existingVuln.trivially_updatable && newVuln.trivially_updatable;
       });
     });
     return vulnsWithMetadata;
@@ -109,8 +118,8 @@ export class DependencyTree<DependencyEdge extends DependencyEdgePartial> {
   // this is the main function that we call to return useful information to the client about their vulnerabilities
   // Todo: The nice generic typing in the return type has been given up on for now (DependencyEdgePartial instead of DependencyEdge), it would be nice to fix it, but its maybe not worth it
   // Also this method is too long but also really hard to break up because of all the computed state from various steps
-  private getVulnerableReleases(): VulnerableRelease<DependencyEdgePartial>[] {
-    const vulnerableReleasesById: Record<string, VulnerableRelease<DependencyEdge>> = {};
+  private getVulnerableReleases(): VulnerableRelease[] {
+    const vulnerableReleasesById: Record<string, VulnerableRelease> = {};
 
     this.vulnerableDepNodeIds.forEach((nodeId) => {
       const vulnerableDep = this.depNodesById.get(nodeId);
@@ -144,14 +153,14 @@ export class DependencyTree<DependencyEdge extends DependencyEdgePartial> {
 
         // We arent tracking this release yet, make a new object
         if (!existingRelease) {
-          const newVulnerableRelease: VulnerableRelease<DependencyEdge> = {
+          const newVulnerableRelease: VulnerableRelease = {
             release,
             severity,
             cvss: affectedByVuln.vulnerability.cvss_score || null,
-            devOnly,
+            dev_only: devOnly,
             chains,
-            triviallyUpdatable: this.checkIfReleaseTriviallyUpdatable(release.id),
-            affectedBy: [affectedByVuln],
+            trivially_updatable: this.checkIfReleaseTriviallyUpdatable(release.id),
+            affected_by: [affectedByVuln],
           };
           vulnerableReleasesById[release.id] = newVulnerableRelease;
           return;
@@ -159,7 +168,7 @@ export class DependencyTree<DependencyEdge extends DependencyEdgePartial> {
         // We are already tracking this release, just merge the new information
 
         // devOnly will be false if ANY nodes aren't devOnly
-        existingRelease.devOnly = devOnly && existingRelease.devOnly;
+        existingRelease.dev_only = devOnly && existingRelease.dev_only;
         // take the highest cvss
         if (
           affectedByVuln.vulnerability.cvss_score &&
@@ -172,8 +181,8 @@ export class DependencyTree<DependencyEdge extends DependencyEdgePartial> {
           existingRelease.severity = severity;
         }
         // add vuln to the release if its not being tracked yet
-        if (!existingRelease.affectedBy.some((v) => v.vulnerability.id === affectedByVuln.vulnerability.id)) {
-          existingRelease.affectedBy.push(affectedByVuln);
+        if (!existingRelease.affected_by.some((v) => v.vulnerability.id === affectedByVuln.vulnerability.id)) {
+          existingRelease.affected_by.push(affectedByVuln);
         }
         // add chains to the top level list of chains on the release, if this is the first vuln we have process on the edge (because we only want to do this once per edge)
         if (vulnIndex === 0) {
@@ -184,17 +193,15 @@ export class DependencyTree<DependencyEdge extends DependencyEdgePartial> {
     return Object.values(vulnerableReleasesById);
   }
 
-  private chainsAreIdentical(
-    firstChain: DependencyChain<DependencyEdge['child']>,
-    secondChain: DependencyChain<DependencyEdge['child']>
-  ): boolean {
+  // unused but could come in handy someday
+  private chainsAreIdentical(firstChain: DependencyChain, secondChain: DependencyChain): boolean {
     if (firstChain.length !== secondChain.length) {
       return false;
     }
     return !firstChain.some((dep, i) => dep.id !== secondChain[i].id);
   }
 
-  private precomputeVulnTriviallyUpdatable(requestedRange: string, vuln: VulnWithMetadata): boolean {
+  private precomputeVulnTriviallyUpdatable(requestedRange: string, vuln: RawVulnMeta): boolean {
     const fixedVersions: string[] = [];
     vuln.ranges.forEach((range) => {
       if (range.fixed) {
@@ -206,7 +213,7 @@ export class DependencyTree<DependencyEdge extends DependencyEdgePartial> {
     });
   }
 
-  public convertRangesToSemverRange(ranges: VulnWithMetadata['ranges']): semver.Range {
+  public convertRangesToSemverRange(ranges: RawVulnMeta['ranges']): semver.Range {
     const vulnerableRanges: string[] = [];
     ranges.forEach((range) => {
       if (range.introduced && range.fixed) {
@@ -239,11 +246,11 @@ export class DependencyTree<DependencyEdge extends DependencyEdgePartial> {
     const fullyUpdatableDeps = matchingDeps.filter((dep) => {
       return dep.release.package.affected_by_vulnerability.every((affectedByVuln) => {
         totalVulnCount++; // also keep track of the vuln count while we are in this loop
-        return affectedByVuln.triviallyUpdatable;
+        return affectedByVuln.trivially_updatable;
       });
     });
     const atLeastPartiallyUpdatableDeps = matchingDeps.filter((dep) => {
-      return dep.release.package.affected_by_vulnerability.some((affectedByVuln) => affectedByVuln.triviallyUpdatable);
+      return dep.release.package.affected_by_vulnerability.some((affectedByVuln) => affectedByVuln.trivially_updatable);
     });
 
     const fullUpdateCount = fullyUpdatableDeps.length;
@@ -263,17 +270,14 @@ export class DependencyTree<DependencyEdge extends DependencyEdgePartial> {
   }
 
   // Show us how a dependency is being included by other dependencies by creating a "chain".
-  private getDependencyChainsOfDepNode(depNode: DependencyEdge['child']): DependencyChain<DependencyEdge['child']>[] {
-    const flattenedChains: DependencyChain<DependencyEdge['child']>[] = [];
+  private getDependencyChainsOfDepNode(depNode: BuiltNode): DependencyChain[] {
+    const flattenedChains: DependencyChain[] = [];
 
     // Flatten the chains
-    const recursivelyGenerateChainsWithStack = (
-      dep: DependencyEdge['child'],
-      stack: DependencyChain<DependencyEdge['child']>
-    ) => {
+    const recursivelyGenerateChainsWithStack = (dep: BuiltNode, stack: DependencyChain) => {
       // Fastest way to clone into a new array, with root at front and leaf at end
       const stackLength = stack.length;
-      const newStack = new Array<DependencyEdge['child']>(stackLength + 1);
+      const newStack = new Array<BuiltNode>(stackLength + 1);
       newStack[0] = dep;
       for (let i = 0; i < stackLength; i++) {
         newStack[i + 1] = stack[i];

--- a/lunatrace/bsl/backend/src/models/dependency-tree/types.ts
+++ b/lunatrace/bsl/backend/src/models/dependency-tree/types.ts
@@ -19,8 +19,10 @@ export interface DependencyEdgePartial {
   child_id: string;
   // multiple edges could have the same parent, but no edges can have the same child and parent
   parent_id?: string;
+  id: string;
   child: {
     id: string;
+    edge_id: string;
     parent_id?: string; // we dump this in here as we build the tree so we can forget about edges
     range: string;
     release_id: string;
@@ -36,12 +38,12 @@ interface Release {
 }
 
 interface Package {
-  affected_by_vulnerability: Array<AffectedByVulnerability>;
+  affected_by_vulnerability: Array<VulnWithMetadata>;
   name: string;
   package_manager: string;
 }
 
-export interface AffectedByVulnerability {
+export interface VulnWithMetadata {
   vulnerability: {
     id: string;
     severity_name?: string;
@@ -67,6 +69,6 @@ export interface VulnerableRelease<DependencyEdge extends DependencyEdgePartial>
   chains: DependencyChain<DependencyEdge['child']>[];
   cvss: number | null; // the highest rating from all the vulns on the release, used for giving the user an at-a-glance rating
   devOnly: boolean;
-  affectedBy: Array<AffectedByVulnerability>;
+  affectedBy: Array<VulnWithMetadata>;
   triviallyUpdatable: 'no' | 'partially' | 'yes';
 }

--- a/lunatrace/bsl/backend/src/models/dependency-tree/types.ts
+++ b/lunatrace/bsl/backend/src/models/dependency-tree/types.ts
@@ -12,9 +12,10 @@
  *
  */
 
-// Represents a subset of the incoming data from hasura about a tree element
+/* -------------------------------------------------------------------------- */
+/*              Below are input data as it comes from the database            */
+/* -------------------------------------------------------------------------- */
 
-// ----------- RAW INPUT DATA, LIKE WE EXPECT TO GET IT FROM HASURA -----------------------------------------------------------------------------
 export interface RawEdge {
   child_id: string;
   parent_id?: string;
@@ -58,6 +59,10 @@ export interface RawVulnMeta {
 }
 
 // ------------------ COMPUTED OUTPUT DATA, WITH FIELDS OUR USERS WANT --------------------------
+
+/* -------------------------------------------------------------------------- */
+/*              Below are output data that we return from the tree            */
+/* -------------------------------------------------------------------------- */
 
 export interface BuiltNode extends RawNode {
   // we dump these in here as we build the tree so we can forget about edges, because edges are confusing

--- a/lunatrace/bsl/backend/src/models/dependency-tree/types.ts
+++ b/lunatrace/bsl/backend/src/models/dependency-tree/types.ts
@@ -14,36 +14,36 @@
 
 // Represents a subset of the incoming data from hasura about a tree element
 
-export interface DependencyEdgePartial {
-  // multiple edges could have the same child id/ the same child
+// ----------- RAW INPUT DATA, LIKE WE EXPECT TO GET IT FROM HASURA -----------------------------------------------------------------------------
+export interface RawEdge {
   child_id: string;
-  // multiple edges could have the same parent, but no edges can have the same child and parent
   parent_id?: string;
   id: string;
-  child: {
-    id: string;
-    edge_id: string;
-    parent_id?: string; // we dump this in here as we build the tree so we can forget about edges
-    range: string;
-    release_id: string;
-    release: Release;
-    labels?: Record<string | number | symbol, unknown>;
-  };
+  child: RawNode;
 }
 
-interface Release {
+// Referred to as a "manifest_dependency_node" in the database, which we shorted here to "node"
+export interface RawNode {
+  id: string;
+  range: string;
+  release_id: string;
+  release: RawRelease;
+  labels?: Record<string | number | symbol, unknown>;
+}
+
+interface RawRelease {
   id: string;
   version: string;
-  package: Package;
+  package: RawPackage;
 }
 
-interface Package {
-  affected_by_vulnerability: Array<VulnWithMetadata>;
+interface RawPackage {
+  affected_by_vulnerability: Array<RawVulnMeta>;
   name: string;
   package_manager: string;
 }
 
-export interface VulnWithMetadata {
+export interface RawVulnMeta {
   vulnerability: {
     id: string;
     severity_name?: string;
@@ -55,20 +55,40 @@ export interface VulnWithMetadata {
     introduced?: string | null;
     fixed?: string | null;
   }>;
-  triviallyUpdatable?: boolean; // We add this by determining something can be updated to a non-vulnerable version without violating semver
-  chains?: DependencyChain<DependencyEdgePartial['child']>[]; // each vuln has its own sublist of chains in addition to the global list in the main body of the release. This is in case some have been eliminated by false-positive analysis for only this vuln
 }
 
-export type DependencyChain<D extends DependencyEdgePartial['child']> = Array<D>;
+// ------------------ COMPUTED OUTPUT DATA, WITH FIELDS OUR USERS WANT --------------------------
+
+export interface BuiltNode extends RawNode {
+  // we dump these in here as we build the tree so we can forget about edges, because edges are confusing
+  edge_id: string;
+  parent_id?: string;
+  release: BuiltRelease;
+}
+
+export interface BuiltRelease extends RawRelease {
+  package: BuiltPackage;
+}
+
+interface BuiltPackage extends RawPackage {
+  affected_by_vulnerability: Array<BuiltVulnMeta>;
+}
+
+export interface BuiltVulnMeta extends RawVulnMeta {
+  trivially_updatable: boolean; // We add this by determining something can be updated to a non-vulnerable version without violating semver
+  chains: DependencyChain[]; // each vuln has its own sublist of chains in addition to the global list in the main body of the release. This is in case some have been eliminated by false-positive analysis for only this vuln
+}
+
+export type DependencyChain = Array<BuiltNode>;
 
 // This is the OUTPUT/RESPONSE type that we generate from the tree (from the above data types) and return to the client or consumer.
 // Note that it references many of the same types as above, as this is essentially just a reorganization and subset of the above data, with some additional computed fields such as devOnly
-export interface VulnerableRelease<DependencyEdge extends DependencyEdgePartial> {
-  release: Release;
+export interface VulnerableRelease {
+  release: BuiltRelease;
   severity: string;
-  chains: DependencyChain<DependencyEdge['child']>[];
+  chains: DependencyChain[];
   cvss: number | null; // the highest rating from all the vulns on the release, used for giving the user an at-a-glance rating
-  devOnly: boolean;
-  affectedBy: Array<VulnWithMetadata>;
-  triviallyUpdatable: 'no' | 'partially' | 'yes';
+  dev_only: boolean;
+  affected_by: Array<BuiltVulnMeta>;
+  trivially_updatable: 'no' | 'partially' | 'yes';
 }

--- a/lunatrace/bsl/backend/src/models/dependency-tree/types.ts
+++ b/lunatrace/bsl/backend/src/models/dependency-tree/types.ts
@@ -13,7 +13,7 @@
  */
 
 /* -------------------------------------------------------------------------- */
-/*              Below are input data as it comes from the database            */
+/*                    Input data as it comes from the database                */
 /* -------------------------------------------------------------------------- */
 
 export interface RawEdge {
@@ -58,10 +58,8 @@ export interface RawVulnMeta {
   }>;
 }
 
-// ------------------ COMPUTED OUTPUT DATA, WITH FIELDS OUR USERS WANT --------------------------
-
 /* -------------------------------------------------------------------------- */
-/*              Below are output data that we return from the tree            */
+/*                  Output data that is returned from the tree                */
 /* -------------------------------------------------------------------------- */
 
 export interface BuiltNode extends RawNode {

--- a/lunatrace/bsl/backend/src/tests/builds-dependency-tree.test.ts
+++ b/lunatrace/bsl/backend/src/tests/builds-dependency-tree.test.ts
@@ -12,6 +12,8 @@
  *
  */
 
+import util from 'util';
+
 import { fakeDependencyTreeHasuraOutputFixture } from '../fixtures/manifests/fake-dependency-tree-hasura-output-fixture';
 import { DependencyTree } from '../models/dependency-tree/builds-dependency-tree';
 
@@ -21,16 +23,28 @@ describe('The dependency tree', () => {
     expect(tree).toBeDefined();
     expect(tree.depNodesById.size).toEqual(4);
     expect(tree.nodeIdToParentIds.size).toEqual(3);
-    expect(tree.vulnIdToVulns.size).toEqual(1);
     // parse out vulnerable releases and check the data
-    const vulnReleases = tree.getVulnerableReleases();
+    const vulnReleases = tree.vulnerableReleases;
     expect(vulnReleases.length).toEqual(1);
 
     const vulnQux = vulnReleases[0];
-    expect(vulnQux.triviallyUpdatable).toEqual('yes');
+    expect(vulnQux.trivially_updatable).toEqual('yes');
     expect(vulnQux.chains.length).toEqual(1);
+    const chain = vulnQux.chains[0];
 
-    const chainPackageNames = vulnQux.chains[0].map((dep) => dep.release.package.name);
+    const chainPackageNames = chain.map((dep) => dep.release.package.name);
     expect(chainPackageNames).toEqual(['foo', 'bar', 'baz', 'qux']);
+
+    const leafNode = chain[chain.length - 1];
+    expect(leafNode.id).toEqual('4');
+  });
+
+  it('should show all vulnerabilities with getVulnerabilities()', () => {
+    const tree = new DependencyTree(fakeDependencyTreeHasuraOutputFixture);
+    const vulnerabilities = tree.getVulnerabilities();
+    expect(vulnerabilities.length).toEqual(1);
+    expect(vulnerabilities[0].vulnerability.source_id).toEqual('GHSA123ABC');
+    expect(vulnerabilities[0].chains.length).toEqual(1);
+    expect(vulnerabilities[0].chains[0].length).toEqual(4);
   });
 });

--- a/lunatrace/bsl/docker-compose.yaml
+++ b/lunatrace/bsl/docker-compose.yaml
@@ -123,8 +123,8 @@ services:
       # TODO: ADD THIS TO THE CDK
       REMOTE_SCHEMA_URL: http://host.docker.internal:3002/graphql/v1
       # COMMENT OUT THESE DIRs IF HASURA WONT START DUE TO MIGRATION OR METADATA ISSUES
-      HASURA_GRAPHQL_METADATA_DIR: /hasura/metadata
-      HASURA_GRAPHQL_MIGRATIONS_DIR: /hasura/migrations
+#      HASURA_GRAPHQL_METADATA_DIR: /hasura/metadata
+#      HASURA_GRAPHQL_MIGRATIONS_DIR: /hasura/migrations
     extra_hosts:
       - "host.docker.internal:host-gateway"
 

--- a/lunatrace/bsl/docker-compose.yaml
+++ b/lunatrace/bsl/docker-compose.yaml
@@ -123,8 +123,8 @@ services:
       # TODO: ADD THIS TO THE CDK
       REMOTE_SCHEMA_URL: http://host.docker.internal:3002/graphql/v1
       # COMMENT OUT THESE DIRs IF HASURA WONT START DUE TO MIGRATION OR METADATA ISSUES
-#      HASURA_GRAPHQL_METADATA_DIR: /hasura/metadata
-#      HASURA_GRAPHQL_MIGRATIONS_DIR: /hasura/migrations
+      HASURA_GRAPHQL_METADATA_DIR: /hasura/metadata
+      HASURA_GRAPHQL_MIGRATIONS_DIR: /hasura/migrations
     extra_hosts:
       - "host.docker.internal:host-gateway"
 

--- a/lunatrace/bsl/frontend/src/api/generated.ts
+++ b/lunatrace/bsl/frontend/src/api/generated.ts
@@ -50,7 +50,7 @@ export type BuildData_AffectedByVulnerability = {
   __typename?: 'BuildData_AffectedByVulnerability';
   chains?: Maybe<Array<Array<BuildData_DependencyNode>>>;
   ranges?: Maybe<Array<Maybe<BuildData_Range>>>;
-  triviallyUpdatable?: Maybe<Scalars['Boolean']>;
+  trivially_updatable?: Maybe<Scalars['Boolean']>;
   vulnerability: BuildData_Vulnerability;
 };
 
@@ -89,18 +89,17 @@ export type BuildData_Vulnerability = {
   severity_name?: Maybe<Scalars['String']>;
   source: Scalars['String'];
   source_id: Scalars['String'];
-  triviallyUpdatable?: Maybe<Scalars['String']>;
 };
 
 export type BuildData_VulnerableRelease = {
   __typename?: 'BuildData_VulnerableRelease';
-  affectedBy: Array<BuildData_AffectedByVulnerability>;
+  affected_by: Array<BuildData_AffectedByVulnerability>;
   chains: Array<Array<BuildData_DependencyNode>>;
   cvss?: Maybe<Scalars['Float']>;
-  devOnly: Scalars['Boolean'];
+  dev_only: Scalars['Boolean'];
   release?: Maybe<BuildData_Release>;
   severity?: Maybe<Scalars['String']>;
-  triviallyUpdatable: Scalars['String'];
+  trivially_updatable: Scalars['String'];
 };
 
 /** Boolean expression to compare columns of type "Float". All fields are combined with logical 'AND'. */
@@ -2419,6 +2418,7 @@ export type Manifest_Dependency_Edge = {
   /** An object relationship */
   child: Manifest_Dependency_Node;
   child_id: Scalars['uuid'];
+  id: Scalars['uuid'];
   /** An object relationship */
   parent: Manifest_Dependency_Node;
   parent_id: Scalars['uuid'];
@@ -2438,6 +2438,7 @@ export type Manifest_Dependency_Edge_Bool_Exp = {
   _or?: InputMaybe<Array<Manifest_Dependency_Edge_Bool_Exp>>;
   child?: InputMaybe<Manifest_Dependency_Node_Bool_Exp>;
   child_id?: InputMaybe<Uuid_Comparison_Exp>;
+  id?: InputMaybe<Uuid_Comparison_Exp>;
   parent?: InputMaybe<Manifest_Dependency_Node_Bool_Exp>;
   parent_id?: InputMaybe<Uuid_Comparison_Exp>;
 };
@@ -2445,12 +2446,14 @@ export type Manifest_Dependency_Edge_Bool_Exp = {
 /** order by max() on columns of table "manifest_dependency_edge" */
 export type Manifest_Dependency_Edge_Max_Order_By = {
   child_id?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
   parent_id?: InputMaybe<Order_By>;
 };
 
 /** order by min() on columns of table "manifest_dependency_edge" */
 export type Manifest_Dependency_Edge_Min_Order_By = {
   child_id?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
   parent_id?: InputMaybe<Order_By>;
 };
 
@@ -2458,6 +2461,7 @@ export type Manifest_Dependency_Edge_Min_Order_By = {
 export type Manifest_Dependency_Edge_Order_By = {
   child?: InputMaybe<Manifest_Dependency_Node_Order_By>;
   child_id?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
   parent?: InputMaybe<Manifest_Dependency_Node_Order_By>;
   parent_id?: InputMaybe<Order_By>;
 };
@@ -2466,6 +2470,8 @@ export type Manifest_Dependency_Edge_Order_By = {
 export enum Manifest_Dependency_Edge_Select_Column {
   /** column name */
   ChildId = 'child_id',
+  /** column name */
+  Id = 'id',
   /** column name */
   ParentId = 'parent_id'
 }
@@ -4086,6 +4092,8 @@ export type Query_Root = {
   manifest_dependency: Array<Manifest_Dependency>;
   /** fetch data from the table: "manifest_dependency_edge" */
   manifest_dependency_edge: Array<Manifest_Dependency_Edge>;
+  /** fetch data from the table: "manifest_dependency_edge" using primary key columns */
+  manifest_dependency_edge_by_pk?: Maybe<Manifest_Dependency_Edge>;
   /** fetch data from the table: "manifest_dependency_node" */
   manifest_dependency_node: Array<Manifest_Dependency_Node>;
   /** fetch data from the table: "manifest_dependency_node" using primary key columns */
@@ -4393,6 +4401,11 @@ export type Query_RootManifest_Dependency_EdgeArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   order_by?: InputMaybe<Array<Manifest_Dependency_Edge_Order_By>>;
   where?: InputMaybe<Manifest_Dependency_Edge_Bool_Exp>;
+};
+
+
+export type Query_RootManifest_Dependency_Edge_By_PkArgs = {
+  id: Scalars['uuid'];
 };
 
 
@@ -5252,6 +5265,8 @@ export type Subscription_Root = {
   manifest_dependency: Array<Manifest_Dependency>;
   /** fetch data from the table: "manifest_dependency_edge" */
   manifest_dependency_edge: Array<Manifest_Dependency_Edge>;
+  /** fetch data from the table: "manifest_dependency_edge" using primary key columns */
+  manifest_dependency_edge_by_pk?: Maybe<Manifest_Dependency_Edge>;
   /** fetch data from the table: "manifest_dependency_node" */
   manifest_dependency_node: Array<Manifest_Dependency_Node>;
   /** fetch data from the table: "manifest_dependency_node" using primary key columns */
@@ -5550,6 +5565,11 @@ export type Subscription_RootManifest_Dependency_EdgeArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   order_by?: InputMaybe<Array<Manifest_Dependency_Edge_Order_By>>;
   where?: InputMaybe<Manifest_Dependency_Edge_Bool_Exp>;
+};
+
+
+export type Subscription_RootManifest_Dependency_Edge_By_PkArgs = {
+  id: Scalars['uuid'];
 };
 
 
@@ -6924,7 +6944,7 @@ export type GetVulnerableReleasesFromBuildQueryVariables = Exact<{
 }>;
 
 
-export type GetVulnerableReleasesFromBuildQuery = { __typename?: 'query_root', vulnerableReleasesFromBuild?: Array<{ __typename?: 'BuildData_VulnerableRelease', triviallyUpdatable: string, cvss?: number | null, severity?: string | null, devOnly: boolean, chains: Array<Array<{ __typename?: 'BuildData_DependencyNode', id: string, range: string, release: { __typename?: 'BuildData_Release', id: string, version: string, package: { __typename?: 'BuildData_Package', name: string } } }>>, release?: { __typename?: 'BuildData_Release', version: string, id: string, package: { __typename?: 'BuildData_Package', name: string } } | null, affectedBy: Array<{ __typename?: 'BuildData_AffectedByVulnerability', triviallyUpdatable?: boolean | null, vulnerability: { __typename?: 'BuildData_Vulnerability', severity_name?: string | null, cvss_score?: number | null, source: string, source_id: string }, chains?: Array<Array<{ __typename?: 'BuildData_DependencyNode', id: string, range: string, release: { __typename?: 'BuildData_Release', id: string, version: string, package: { __typename?: 'BuildData_Package', name: string } } }>> | null }> }> | null };
+export type GetVulnerableReleasesFromBuildQuery = { __typename?: 'query_root', vulnerableReleasesFromBuild?: Array<{ __typename?: 'BuildData_VulnerableRelease', trivially_updatable: string, cvss?: number | null, severity?: string | null, dev_only: boolean, chains: Array<Array<{ __typename?: 'BuildData_DependencyNode', id: string, range: string, release: { __typename?: 'BuildData_Release', id: string, version: string, package: { __typename?: 'BuildData_Package', name: string } } }>>, release?: { __typename?: 'BuildData_Release', version: string, id: string, package: { __typename?: 'BuildData_Package', name: string } } | null, affected_by: Array<{ __typename?: 'BuildData_AffectedByVulnerability', trivially_updatable?: boolean | null, vulnerability: { __typename?: 'BuildData_Vulnerability', severity_name?: string | null, cvss_score?: number | null, source: string, source_id: string }, chains?: Array<Array<{ __typename?: 'BuildData_DependencyNode', id: string, range: string, release: { __typename?: 'BuildData_Release', id: string, version: string, package: { __typename?: 'BuildData_Package', name: string } } }>> | null }> }> | null };
 
 export type InsertNewOrgUserMutationVariables = Exact<{
   organization_id: Scalars['uuid'];
@@ -7640,10 +7660,10 @@ export const GetVulnerabilityDetailsDocument = `
 export const GetVulnerableReleasesFromBuildDocument = `
     query GetVulnerableReleasesFromBuild($build_id: uuid!) {
   vulnerableReleasesFromBuild(buildId: $build_id) {
-    triviallyUpdatable
+    trivially_updatable
     cvss
     severity
-    devOnly
+    dev_only
     chains {
       id
       range
@@ -7661,8 +7681,8 @@ export const GetVulnerableReleasesFromBuildDocument = `
         name
       }
     }
-    affectedBy {
-      triviallyUpdatable
+    affected_by {
+      trivially_updatable
       vulnerability {
         severity_name
         cvss_score
@@ -7681,7 +7701,7 @@ export const GetVulnerableReleasesFromBuildDocument = `
         }
       }
     }
-    devOnly
+    dev_only
     release {
       id
     }

--- a/lunatrace/bsl/frontend/src/api/graphql/getVulnerableReleasesFromBuild.graphql
+++ b/lunatrace/bsl/frontend/src/api/graphql/getVulnerableReleasesFromBuild.graphql
@@ -1,9 +1,9 @@
 query GetVulnerableReleasesFromBuild($build_id: uuid!) {
     vulnerableReleasesFromBuild(buildId: $build_id) {
-        triviallyUpdatable
+        trivially_updatable
         cvss
         severity
-        devOnly
+        dev_only
         chains {
             id
             range
@@ -21,8 +21,8 @@ query GetVulnerableReleasesFromBuild($build_id: uuid!) {
                 name
             }
         }
-        affectedBy {
-            triviallyUpdatable
+        affected_by {
+            trivially_updatable
             vulnerability{
                 severity_name
                 cvss_score
@@ -41,7 +41,7 @@ query GetVulnerableReleasesFromBuild($build_id: uuid!) {
                 }
             }
         }
-        devOnly
+        dev_only
         release {
             id
         }

--- a/lunatrace/schema.graphql
+++ b/lunatrace/schema.graphql
@@ -13,6 +13,10 @@ directive @cached(
   ttl: Int! = 60
 ) on QUERY
 
+type AuthenticatedRepoCloneUrlOutput {
+  url: String
+}
+
 """
 Boolean expression to compare columns of type "Boolean". All fields are combined with logical 'AND'.
 """
@@ -26,6 +30,55 @@ input Boolean_comparison_exp {
   _lte: Boolean
   _neq: Boolean
   _nin: [Boolean!]
+}
+
+type BuildData_AffectedByVulnerability {
+  chains: [[BuildData_DependencyNode!]!]
+  ranges: [BuildData_Range]
+  trivially_updatable: Boolean
+  vulnerability: BuildData_Vulnerability!
+}
+
+type BuildData_DependencyNode {
+  id: String!
+  range: String!
+  release: BuildData_Release!
+  release_id: String!
+}
+
+type BuildData_Package {
+  affected_by_vulnerability: [BuildData_AffectedByVulnerability!]
+  name: String!
+  package_manager: String!
+}
+
+type BuildData_Range {
+  fixed: String
+  introduced: String
+}
+
+type BuildData_Release {
+  id: String!
+  package: BuildData_Package!
+  version: String!
+}
+
+type BuildData_Vulnerability {
+  cvss_score: Float
+  id: String!
+  severity_name: String
+  source: String!
+  source_id: String!
+}
+
+type BuildData_VulnerableRelease {
+  affected_by: [BuildData_AffectedByVulnerability!]!
+  chains: [[BuildData_DependencyNode!]!]!
+  cvss: Float
+  dev_only: Boolean!
+  release: BuildData_Release
+  severity: String
+  trivially_updatable: String!
 }
 
 """
@@ -43,6 +96,23 @@ input Float_comparison_exp {
   _nin: [Float!]
 }
 
+type GithubRepository {
+  cloneUrl: String!
+  defaultBranch: String!
+  gitUrl: String!
+  orgId: Int!
+  orgName: String!
+  orgNodeId: String!
+  ownerType: String!
+  repoId: Int!
+  repoName: String!
+  repoNodeId: String!
+}
+
+type InstallSelectedReposResponse {
+  success: Boolean
+}
+
 """
 Boolean expression to compare columns of type "Int". All fields are combined with logical 'AND'.
 """
@@ -56,6 +126,29 @@ input Int_comparison_exp {
   _lte: Int
   _neq: Int
   _nin: [Int!]
+}
+
+type OrgWithRepos {
+  id: String!
+  organizationName: String!
+  repos: [GithubRepository!]!
+}
+
+input OrgsWithReposInput {
+  id: String!
+  repos: [Int!]!
+}
+
+type PresignedUrlResponse {
+  bucket: String!
+  headers: jsonb!
+  key: String!
+  url: String!
+}
+
+type SbomUploadUrlOutput {
+  error: Boolean!
+  uploadUrl: UploadUrl
 }
 
 """
@@ -109,6 +202,11 @@ input String_comparison_exp {
 
   """does the column match the given SQL regular expression"""
   _similar: String
+}
+
+type UploadUrl {
+  headers: jsonb!
+  url: String!
 }
 
 scalar _text
@@ -881,6 +979,7 @@ type builds {
     where: resolved_manifest_bool_exp
   ): [resolved_manifest!]!
   s3_url: String
+  s3_url_signed: String
 
   """An array relationship"""
   scans(
@@ -2085,6 +2184,7 @@ input fix_state_enum_comparison_exp {
 
 """Metadata about a github repository and where to find it."""
 type github_repositories {
+  authenticated_clone_url: AuthenticatedRepoCloneUrlOutput
   default_branch: String
   git_url: String!
   github_id: Int
@@ -5073,6 +5173,10 @@ type mutation_root {
     """upsert condition"""
     on_conflict: webhook_cache_on_conflict
   ): webhook_cache
+  installSelectedRepos(orgs: [OrgsWithReposInput!]!): InstallSelectedReposResponse
+
+  """ get s3 presigned url for manifest upload, used only by the frontend """
+  presignManifestUpload(project_id: uuid!): PresignedUrlResponse
 
   """
   update data of the table: "analysis.manifest_dependency_edge_result"
@@ -8959,6 +9063,8 @@ type query_root {
   fetch data from the table: "analysis.manifest_dependency_edge_result" using primary key columns
   """
   analysis_manifest_dependency_edge_result_by_pk(id: uuid!): analysis_manifest_dependency_edge_result
+  authenticatedRepoCloneUrl(repoGithubId: Int!): AuthenticatedRepoCloneUrlOutput
+  availableOrgsWithRepos: [OrgWithRepos!]
 
   """
   fetch data from the table: "build_dependency_relationship"
@@ -9064,6 +9170,7 @@ type query_root {
     """filter the rows returned"""
     where: default_branch_builds_bool_exp
   ): [default_branch_builds!]!
+  fakeQueryToHackHasuraBeingABuggyMess: String
 
   """An array relationship"""
   findings(
@@ -9594,6 +9701,9 @@ type query_root {
   """
   package_release_license_by_pk(id: uuid!): package_release_license
 
+  """ get s3 presigned url for manifest upload, used by the CLI """
+  presignSbomUpload(buildId: uuid!, orgId: uuid!): SbomUploadUrlOutput
+
   """An array relationship"""
   project_access_tokens(
     """distinct select on columns"""
@@ -9680,6 +9790,7 @@ type query_root {
   fetch data from the table: "resolved_manifest" using primary key columns
   """
   resolved_manifest_by_pk(id: uuid!): resolved_manifest
+  sbomUrl(buildId: uuid!): String
 
   """An array relationship"""
   scans(
@@ -9967,6 +10078,7 @@ type query_root {
   fetch data from the table: "vulnerability.severity" using primary key columns
   """
   vulnerability_severity_by_pk(id: uuid!): vulnerability_severity
+  vulnerableReleasesFromBuild(buildId: uuid!): [BuildData_VulnerableRelease!]
 
   """
   fetch data from the table: "webhook_cache"


### PR DESCRIPTION
The tree has been reworked to clean up types, field names, and the overall code structure.  

Also, a function has been added to the tree called "getVulnerabilities" which fetches just a list of vulnerabilities from the tree instead of a complete list of vulnerable releases. This will be used for false-positive analysis. 