### PR TITLE
Fix typo on StringSubstitutor in text4shell blog

### DIFF
--- a/docs/blog/2022-10-19-text4shell-cve-2022-42889.mdx
+++ b/docs/blog/2022-10-19-text4shell-cve-2022-42889.mdx
@@ -62,7 +62,7 @@ limited compared with Log4Shell.
 ### Should you patch?
 
 While you're _most likely_ not vulnerable to Text4Shell, the devil is in the details, and we believe that you should
-either upgrade to version 1.10+ or scan your code for usages of `StringSubstitor.createInterpolator()` or
+either upgrade to version 1.10+ or scan your code for usages of `StringSubstitutor.createInterpolator()` or
 `StringLookupFactory.INSTANCE.interpolatorStringLookup().lookup()` to verify that they can't accept arbitrary input.
 
 Note: We're still investigating other attack paths like recursive resolutions. If you find any, please let us know!


### PR DESCRIPTION
It looks like there a typo on StringSubstitor mentioned at some point, it should be StringSubstitutor instead.
