### PR TITLE
Use BuildID for sharding instead of date

### DIFF
--- a/lunatrace/bsl/backend/src/utils/aws-utils.ts
+++ b/lunatrace/bsl/backend/src/utils/aws-utils.ts
@@ -42,6 +42,11 @@ export interface PreSignedUrlGeneratorConfig {
   redirectToLocalhost?: boolean;
 }
 
+// 12345678-9012-... => 12/34/56
+function shardKeyForUUID(uuid: string): string {
+  return (uuid.replace('-', '').match(/.{1,2}/g) || ['unknown']).slice(0, 2).join('/');
+}
+
 export class AwsUtils {
   constructor(readonly config: PreSignedUrlGeneratorConfig) {}
 
@@ -151,9 +156,7 @@ export class AwsUtils {
   public generateSbomS3Key(orgId: string, buildId: string): string {
     const today = new Date();
 
-    return `${encodeURIComponent(
-      orgId
-    )}/${today.getFullYear()}/${today.getMonth()}/${today.getDay()}/${today.getHours()}/${encodeURIComponent(buildId)}`;
+    return `${encodeURIComponent(orgId)}/${shardKeyForUUID(buildId)}/${encodeURIComponent(buildId)}`;
   }
 }
 

--- a/lunatrace/bsl/backend/src/utils/aws-utils.ts
+++ b/lunatrace/bsl/backend/src/utils/aws-utils.ts
@@ -154,8 +154,6 @@ export class AwsUtils {
   }
 
   public generateSbomS3Key(orgId: string, buildId: string): string {
-    const today = new Date();
-
     return `${encodeURIComponent(orgId)}/${shardKeyForUUID(buildId)}/${encodeURIComponent(buildId)}`;
   }
 }


### PR DESCRIPTION
Switches SBOM bucket over to use first characters of uuid as shard keys instead of the date.

Previously, we were writing all snapshots for an org to the same shard because we were sharding by orgID+date. This would have given us a limit of 3500 SBOM PUTs per second per org. We're not hitting that any time soon but this should distribute the load more evenly.