### PR TITLE
Add media to EPSS post, title change

### DIFF
--- a/docs/blog/2022-11-21-epss.mdx
+++ b/docs/blog/2022-11-21-epss.mdx
@@ -21,6 +21,8 @@ authors: [forrest, alex, free]
   ~
 -->
 
+<iframe width="100%" height="400" src="https://www.youtube-nocookie.com/embed/agiHb4peGCI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 ## Vulnerability Severity Scoring
 
 Most Security folks are already familiar with [CVSS](https://www.first.org/cvss/v3.1/specification-document) as a framework used by

--- a/docs/blog/2022-11-21-epss.mdx
+++ b/docs/blog/2022-11-21-epss.mdx
@@ -1,6 +1,6 @@
 ---
-title: "What is EPSS? A new rating system for vulnerabilities to replace CVSS."
-description: "LunaSec Security Researchers give a quick look at the EPSS scoring system, a new rating system for vulnerabilities that aims to replace CVSS"
+title: "What is EPSS? A new rating system for exploitability of vulnerabilities."
+description: "LunaSec Security Researchers give a quick look at the EPSS scoring system, a new rating system for vulnerabilities focused on likelihood of exploitability."
 slug: what-is-epss
 date: 2022-11-21T12:00:00.000Z
 keywords: [cybersecurity, epss, cvss, scoring, first]
@@ -65,7 +65,7 @@ Security Information and Event Management (SIEM) tools.**)
 * Count of how many references are listed in the CVE
 * Published Exploit code in any of: Metasploit, ExploitDB and/or Github
 * Security Scanners: Jaeles, Intrigue, Nuclei, sn1per
-* CVSS v3 vectors in the base score (not the score or any subscores) as published in the National Vulnerability Database (NVD)
+* CVSS v3 vectors as published in the National Vulnerability Database (NVD)
 * CPE (vendor) information as published in NVD
 * Ground Truth: Daily observations of exploitation-in-the-wild activity from AlienVault and Fortinet.
 :::


### PR DESCRIPTION
Adds youtube video to epss post, fits our theme of having media at the top of post.

Changes the title to remove reference to EPSS as a replacement for CVSS. EPSS depends on the CVSS information and they have different use cases so I don't think we should call it a direct replacement.

Replacement was not mentioned in the post except the title