### PR TITLE
Return reduced list of dependency chains

### DIFF
--- a/.github/workflows/lunatrace-unit-test.yaml
+++ b/.github/workflows/lunatrace-unit-test.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: backend-tests
         working-directory: 'lunatrace/bsl/backend'
-        run: yarn run test:jest --verbose
+        run: yarn run test --verbose
 
       - name: logger-tests
         working-directory: 'lunatrace/bsl/logger'

--- a/lunatrace/bsl/backend/package.json
+++ b/lunatrace/bsl/backend/package.json
@@ -16,7 +16,7 @@
     "test:scan:upload": "yarn run ts-node --files ./src/tests/upload-scan.ts",
     "test:load": "yarn run ts-node --files ./src/tests/local-load-vulnerabilities-test.ts",
     "test:queue": "GITHUB_APP_ID=\"179126\" GITHUB_APP_PRIVATE_KEY=\"$(cat github-app-dev.2022-03-09.private-key.pem | base64 -w0)\" yarn run ts-node --files src/manual-scripts/queue-activities.ts",
-    "test:jest": "jest",
+    "test": "jest",
     "guides:update": "yarn run ts-node --files src/guide-ingester/cmd.ts ../../../guides",
     "test:deleted": "yarn run ts-node --files ./src/tests/deleted-vulns-scan.ts",
     "start:prod": "pm2-runtime start --node-args=\"--enable-source-maps\" ./build/server.js --name demo-back-end",

--- a/lunatrace/bsl/backend/src/graphql-yoga/generated-resolver-types.ts
+++ b/lunatrace/bsl/backend/src/graphql-yoga/generated-resolver-types.ts
@@ -208,6 +208,7 @@ export type QuerySbomUrlArgs = {
 export type QueryVulnerableReleasesFromBuildArgs = {
   buildId: Scalars['uuid'];
   minimumSeverity?: InputMaybe<Scalars['String']>;
+  previewChains?: InputMaybe<Scalars['Boolean']>;
 };
 
 export type SbomUploadUrlInput = {

--- a/lunatrace/bsl/backend/src/graphql-yoga/resolvers/vulnerable-releases-from-build.ts
+++ b/lunatrace/bsl/backend/src/graphql-yoga/resolvers/vulnerable-releases-from-build.ts
@@ -38,6 +38,8 @@ export const vulnerableReleasesFromBuildResolver: BuildVulnerabilitiesResolver =
     );
   }
 
+  const previewChains = args.previewChains !== null ? args.previewChains : false;
+
   const depTree = await vulnerabilityTreeFromHasura(logger, buildId, minimumSeverity);
   if (depTree.error) {
     logger.error('unable to build dependency tree', {
@@ -48,7 +50,7 @@ export const vulnerableReleasesFromBuildResolver: BuildVulnerabilitiesResolver =
 
   logger.info('building vulnerable releases');
 
-  const vulnerableReleases = depTree.res.getVulnerableReleases(true);
+  const vulnerableReleases = depTree.res.getVulnerableReleases(previewChains);
 
   logger.info('finished processing tree');
   return vulnerableReleases;

--- a/lunatrace/bsl/backend/src/graphql-yoga/schema.graphql
+++ b/lunatrace/bsl/backend/src/graphql-yoga/schema.graphql
@@ -15,7 +15,7 @@ type Query {
     ): AuthenticatedRepoCloneUrlOutput
     fakeQueryToHackHasuraBeingABuggyMess: String
     availableOrgsWithRepos: [OrgWithRepos!]
-    vulnerableReleasesFromBuild(buildId: uuid!, minimumSeverity: String): [BuildData_VulnerableRelease!]
+    vulnerableReleasesFromBuild(buildId: uuid!, minimumSeverity: String, previewChains: Boolean): [BuildData_VulnerableRelease!]
 }
 
 type Mutation {

--- a/lunatrace/bsl/backend/src/hasura-api/generated.ts
+++ b/lunatrace/bsl/backend/src/hasura-api/generated.ts
@@ -63,7 +63,7 @@ export type BuildData_AffectedByVulnerability = {
 
 export type BuildData_Cwe = {
   __typename?: 'BuildData_Cwe';
-  common_name: Scalars['String'];
+  common_name?: Maybe<Scalars['String']>;
   description: Scalars['String'];
   id: Scalars['Int'];
   name: Scalars['String'];
@@ -321,6 +321,8 @@ export type Analysis_Manifest_Dependency_Edge_Result = {
   finding_source_version: Scalars['Int'];
   finding_type: Analysis_Finding_Type_Enum;
   id: Scalars['uuid'];
+  /** An array relationship */
+  locations: Array<Analysis_Manifest_Dependency_Edge_Result_Location>;
   /** An object relationship */
   manifest_dependency_edge: Manifest_Dependency_Edge;
   manifest_dependency_edge_id: Scalars['uuid'];
@@ -328,6 +330,16 @@ export type Analysis_Manifest_Dependency_Edge_Result = {
   /** An object relationship */
   vulnerability: Vulnerability;
   vulnerability_id: Scalars['uuid'];
+};
+
+
+/** columns and relationships of "analysis.manifest_dependency_edge_result" */
+export type Analysis_Manifest_Dependency_Edge_ResultLocationsArgs = {
+  distinct_on?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Order_By>>;
+  where?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp>;
 };
 
 
@@ -378,6 +390,7 @@ export type Analysis_Manifest_Dependency_Edge_Result_Bool_Exp = {
   finding_source_version?: InputMaybe<Int_Comparison_Exp>;
   finding_type?: InputMaybe<Analysis_Finding_Type_Enum_Comparison_Exp>;
   id?: InputMaybe<Uuid_Comparison_Exp>;
+  locations?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp>;
   manifest_dependency_edge?: InputMaybe<Manifest_Dependency_Edge_Bool_Exp>;
   manifest_dependency_edge_id?: InputMaybe<Uuid_Comparison_Exp>;
   output?: InputMaybe<Jsonb_Comparison_Exp>;
@@ -420,11 +433,250 @@ export type Analysis_Manifest_Dependency_Edge_Result_Insert_Input = {
   finding_source_version?: InputMaybe<Scalars['Int']>;
   finding_type?: InputMaybe<Analysis_Finding_Type_Enum>;
   id?: InputMaybe<Scalars['uuid']>;
+  locations?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Arr_Rel_Insert_Input>;
   manifest_dependency_edge?: InputMaybe<Manifest_Dependency_Edge_Obj_Rel_Insert_Input>;
   manifest_dependency_edge_id?: InputMaybe<Scalars['uuid']>;
   output?: InputMaybe<Scalars['jsonb']>;
   vulnerability?: InputMaybe<Vulnerability_Obj_Rel_Insert_Input>;
   vulnerability_id?: InputMaybe<Scalars['uuid']>;
+};
+
+/** Callsite of a child dependency being imported and used inside of a parent manifest dependency. */
+export type Analysis_Manifest_Dependency_Edge_Result_Location = {
+  __typename?: 'analysis_manifest_dependency_edge_result_location';
+  end_column: Scalars['Int'];
+  end_row: Scalars['Int'];
+  id: Scalars['uuid'];
+  manifest_dependency_edge_result_id: Scalars['uuid'];
+  path: Scalars['String'];
+  start_column: Scalars['Int'];
+  start_row: Scalars['Int'];
+};
+
+/** order by aggregate values of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Aggregate_Order_By = {
+  avg?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Avg_Order_By>;
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Max_Order_By>;
+  min?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Min_Order_By>;
+  stddev?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Stddev_Order_By>;
+  stddev_pop?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Stddev_Pop_Order_By>;
+  stddev_samp?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Stddev_Samp_Order_By>;
+  sum?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Sum_Order_By>;
+  var_pop?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Var_Pop_Order_By>;
+  var_samp?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Var_Samp_Order_By>;
+  variance?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Variance_Order_By>;
+};
+
+/** input type for inserting array relation for remote table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Arr_Rel_Insert_Input = {
+  data: Array<Analysis_Manifest_Dependency_Edge_Result_Location_Insert_Input>;
+  /** upsert condition */
+  on_conflict?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_On_Conflict>;
+};
+
+/** order by avg() on columns of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Avg_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
+};
+
+/** Boolean expression to filter rows from the table "analysis.manifest_dependency_edge_result_location". All fields are combined with a logical 'AND'. */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp = {
+  _and?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp>>;
+  _not?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp>;
+  _or?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp>>;
+  end_column?: InputMaybe<Int_Comparison_Exp>;
+  end_row?: InputMaybe<Int_Comparison_Exp>;
+  id?: InputMaybe<Uuid_Comparison_Exp>;
+  manifest_dependency_edge_result_id?: InputMaybe<Uuid_Comparison_Exp>;
+  path?: InputMaybe<String_Comparison_Exp>;
+  start_column?: InputMaybe<Int_Comparison_Exp>;
+  start_row?: InputMaybe<Int_Comparison_Exp>;
+};
+
+/** unique or primary key constraints on table "analysis.manifest_dependency_edge_result_location" */
+export enum Analysis_Manifest_Dependency_Edge_Result_Location_Constraint {
+  /** unique or primary key constraint on columns "id" */
+  ManifestDependencyEdgeResultCallsitePkey = 'manifest_dependency_edge_result_callsite_pkey'
+}
+
+/** input type for incrementing numeric columns in table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Inc_Input = {
+  end_column?: InputMaybe<Scalars['Int']>;
+  end_row?: InputMaybe<Scalars['Int']>;
+  start_column?: InputMaybe<Scalars['Int']>;
+  start_row?: InputMaybe<Scalars['Int']>;
+};
+
+/** input type for inserting data into table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Insert_Input = {
+  end_column?: InputMaybe<Scalars['Int']>;
+  end_row?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['uuid']>;
+  manifest_dependency_edge_result_id?: InputMaybe<Scalars['uuid']>;
+  path?: InputMaybe<Scalars['String']>;
+  start_column?: InputMaybe<Scalars['Int']>;
+  start_row?: InputMaybe<Scalars['Int']>;
+};
+
+/** order by max() on columns of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Max_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  manifest_dependency_edge_result_id?: InputMaybe<Order_By>;
+  path?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
+};
+
+/** order by min() on columns of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Min_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  manifest_dependency_edge_result_id?: InputMaybe<Order_By>;
+  path?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
+};
+
+/** response of any mutation on the table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Mutation_Response = {
+  __typename?: 'analysis_manifest_dependency_edge_result_location_mutation_response';
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars['Int'];
+  /** data from the rows affected by the mutation */
+  returning: Array<Analysis_Manifest_Dependency_Edge_Result_Location>;
+};
+
+/** on_conflict condition type for table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_On_Conflict = {
+  constraint: Analysis_Manifest_Dependency_Edge_Result_Location_Constraint;
+  update_columns?: Array<Analysis_Manifest_Dependency_Edge_Result_Location_Update_Column>;
+  where?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp>;
+};
+
+/** Ordering options when selecting data from "analysis.manifest_dependency_edge_result_location". */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  manifest_dependency_edge_result_id?: InputMaybe<Order_By>;
+  path?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
+};
+
+/** primary key columns input for table: analysis_manifest_dependency_edge_result_location */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Pk_Columns_Input = {
+  id: Scalars['uuid'];
+};
+
+/** select columns of table "analysis.manifest_dependency_edge_result_location" */
+export enum Analysis_Manifest_Dependency_Edge_Result_Location_Select_Column {
+  /** column name */
+  EndColumn = 'end_column',
+  /** column name */
+  EndRow = 'end_row',
+  /** column name */
+  Id = 'id',
+  /** column name */
+  ManifestDependencyEdgeResultId = 'manifest_dependency_edge_result_id',
+  /** column name */
+  Path = 'path',
+  /** column name */
+  StartColumn = 'start_column',
+  /** column name */
+  StartRow = 'start_row'
+}
+
+/** input type for updating data in table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Set_Input = {
+  end_column?: InputMaybe<Scalars['Int']>;
+  end_row?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['uuid']>;
+  manifest_dependency_edge_result_id?: InputMaybe<Scalars['uuid']>;
+  path?: InputMaybe<Scalars['String']>;
+  start_column?: InputMaybe<Scalars['Int']>;
+  start_row?: InputMaybe<Scalars['Int']>;
+};
+
+/** order by stddev() on columns of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Stddev_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
+};
+
+/** order by stddev_pop() on columns of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Stddev_Pop_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
+};
+
+/** order by stddev_samp() on columns of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Stddev_Samp_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
+};
+
+/** order by sum() on columns of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Sum_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
+};
+
+/** update columns of table "analysis.manifest_dependency_edge_result_location" */
+export enum Analysis_Manifest_Dependency_Edge_Result_Location_Update_Column {
+  /** column name */
+  EndColumn = 'end_column',
+  /** column name */
+  EndRow = 'end_row',
+  /** column name */
+  Id = 'id',
+  /** column name */
+  ManifestDependencyEdgeResultId = 'manifest_dependency_edge_result_id',
+  /** column name */
+  Path = 'path',
+  /** column name */
+  StartColumn = 'start_column',
+  /** column name */
+  StartRow = 'start_row'
+}
+
+/** order by var_pop() on columns of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Var_Pop_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
+};
+
+/** order by var_samp() on columns of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Var_Samp_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
+};
+
+/** order by variance() on columns of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Variance_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
 };
 
 /** order by max() on columns of table "analysis.manifest_dependency_edge_result" */
@@ -468,6 +720,7 @@ export type Analysis_Manifest_Dependency_Edge_Result_Order_By = {
   finding_source_version?: InputMaybe<Order_By>;
   finding_type?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
+  locations_aggregate?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Aggregate_Order_By>;
   manifest_dependency_edge?: InputMaybe<Manifest_Dependency_Edge_Order_By>;
   manifest_dependency_edge_id?: InputMaybe<Order_By>;
   output?: InputMaybe<Order_By>;
@@ -3896,6 +4149,10 @@ export type Mutation_Root = {
   delete_vulnerability_range_by_pk?: Maybe<Vulnerability_Range>;
   /** insert data into the table: "analysis.manifest_dependency_edge_result" */
   insert_analysis_manifest_dependency_edge_result?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Mutation_Response>;
+  /** insert data into the table: "analysis.manifest_dependency_edge_result_location" */
+  insert_analysis_manifest_dependency_edge_result_location?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Location_Mutation_Response>;
+  /** insert a single row into the table: "analysis.manifest_dependency_edge_result_location" */
+  insert_analysis_manifest_dependency_edge_result_location_one?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Location>;
   /** insert a single row into the table: "analysis.manifest_dependency_edge_result" */
   insert_analysis_manifest_dependency_edge_result_one?: Maybe<Analysis_Manifest_Dependency_Edge_Result>;
   /** insert data into the table: "build_dependency_relationship" */
@@ -4053,6 +4310,10 @@ export type Mutation_Root = {
   update_analysis_manifest_dependency_edge_result?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Mutation_Response>;
   /** update single row of the table: "analysis.manifest_dependency_edge_result" */
   update_analysis_manifest_dependency_edge_result_by_pk?: Maybe<Analysis_Manifest_Dependency_Edge_Result>;
+  /** update data of the table: "analysis.manifest_dependency_edge_result_location" */
+  update_analysis_manifest_dependency_edge_result_location?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Location_Mutation_Response>;
+  /** update single row of the table: "analysis.manifest_dependency_edge_result_location" */
+  update_analysis_manifest_dependency_edge_result_location_by_pk?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Location>;
   /** update data of the table: "build_dependency_relationship" */
   update_build_dependency_relationship?: Maybe<Build_Dependency_Relationship_Mutation_Response>;
   /** update single row of the table: "build_dependency_relationship" */
@@ -4270,6 +4531,20 @@ export type Mutation_RootDelete_Vulnerability_Range_By_PkArgs = {
 export type Mutation_RootInsert_Analysis_Manifest_Dependency_Edge_ResultArgs = {
   objects: Array<Analysis_Manifest_Dependency_Edge_Result_Insert_Input>;
   on_conflict?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Analysis_Manifest_Dependency_Edge_Result_LocationArgs = {
+  objects: Array<Analysis_Manifest_Dependency_Edge_Result_Location_Insert_Input>;
+  on_conflict?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Analysis_Manifest_Dependency_Edge_Result_Location_OneArgs = {
+  object: Analysis_Manifest_Dependency_Edge_Result_Location_Insert_Input;
+  on_conflict?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_On_Conflict>;
 };
 
 
@@ -4833,6 +5108,22 @@ export type Mutation_RootUpdate_Analysis_Manifest_Dependency_Edge_Result_By_PkAr
   _prepend?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Prepend_Input>;
   _set?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Set_Input>;
   pk_columns: Analysis_Manifest_Dependency_Edge_Result_Pk_Columns_Input;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Analysis_Manifest_Dependency_Edge_Result_LocationArgs = {
+  _inc?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Inc_Input>;
+  _set?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Set_Input>;
+  where: Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Analysis_Manifest_Dependency_Edge_Result_Location_By_PkArgs = {
+  _inc?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Inc_Input>;
+  _set?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Set_Input>;
+  pk_columns: Analysis_Manifest_Dependency_Edge_Result_Location_Pk_Columns_Input;
 };
 
 
@@ -7609,6 +7900,10 @@ export type Query_Root = {
   analysis_manifest_dependency_edge_result: Array<Analysis_Manifest_Dependency_Edge_Result>;
   /** fetch data from the table: "analysis.manifest_dependency_edge_result" using primary key columns */
   analysis_manifest_dependency_edge_result_by_pk?: Maybe<Analysis_Manifest_Dependency_Edge_Result>;
+  /** fetch data from the table: "analysis.manifest_dependency_edge_result_location" */
+  analysis_manifest_dependency_edge_result_location: Array<Analysis_Manifest_Dependency_Edge_Result_Location>;
+  /** fetch data from the table: "analysis.manifest_dependency_edge_result_location" using primary key columns */
+  analysis_manifest_dependency_edge_result_location_by_pk?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Location>;
   authenticatedRepoCloneUrl?: Maybe<AuthenticatedRepoCloneUrlOutput>;
   availableOrgsWithRepos?: Maybe<Array<OrgWithRepos>>;
   /** fetch data from the table: "build_dependency_relationship" */
@@ -7803,6 +8098,20 @@ export type Query_RootAnalysis_Manifest_Dependency_Edge_ResultArgs = {
 
 
 export type Query_RootAnalysis_Manifest_Dependency_Edge_Result_By_PkArgs = {
+  id: Scalars['uuid'];
+};
+
+
+export type Query_RootAnalysis_Manifest_Dependency_Edge_Result_LocationArgs = {
+  distinct_on?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Order_By>>;
+  where?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp>;
+};
+
+
+export type Query_RootAnalysis_Manifest_Dependency_Edge_Result_Location_By_PkArgs = {
   id: Scalars['uuid'];
 };
 
@@ -8975,6 +9284,10 @@ export type Subscription_Root = {
   analysis_manifest_dependency_edge_result: Array<Analysis_Manifest_Dependency_Edge_Result>;
   /** fetch data from the table: "analysis.manifest_dependency_edge_result" using primary key columns */
   analysis_manifest_dependency_edge_result_by_pk?: Maybe<Analysis_Manifest_Dependency_Edge_Result>;
+  /** fetch data from the table: "analysis.manifest_dependency_edge_result_location" */
+  analysis_manifest_dependency_edge_result_location: Array<Analysis_Manifest_Dependency_Edge_Result_Location>;
+  /** fetch data from the table: "analysis.manifest_dependency_edge_result_location" using primary key columns */
+  analysis_manifest_dependency_edge_result_location_by_pk?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Location>;
   /** fetch data from the table: "build_dependency_relationship" */
   build_dependency_relationship: Array<Build_Dependency_Relationship>;
   /** fetch data from the table: "build_dependency_relationship" using primary key columns */
@@ -9162,6 +9475,20 @@ export type Subscription_RootAnalysis_Manifest_Dependency_Edge_ResultArgs = {
 
 
 export type Subscription_RootAnalysis_Manifest_Dependency_Edge_Result_By_PkArgs = {
+  id: Scalars['uuid'];
+};
+
+
+export type Subscription_RootAnalysis_Manifest_Dependency_Edge_Result_LocationArgs = {
+  distinct_on?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Order_By>>;
+  where?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp>;
+};
+
+
+export type Subscription_RootAnalysis_Manifest_Dependency_Edge_Result_Location_By_PkArgs = {
   id: Scalars['uuid'];
 };
 
@@ -11742,9 +12069,7 @@ export type Vulnerability_Vulnerability_Cwe_Bool_Exp = {
 /** unique or primary key constraints on table "vulnerability.vulnerability_cwe" */
 export enum Vulnerability_Vulnerability_Cwe_Constraint {
   /** unique or primary key constraint on columns "id" */
-  VulnerabilityCwePkey = 'vulnerability_cwe_pkey',
-  /** unique or primary key constraint on columns "cwe_id", "vulnerability_id" */
-  VulnerabilityCweVulnerabilityIdCweIdKey = 'vulnerability_cwe_vulnerability_id_cwe_id_key'
+  VulnerabilityCwePkey = 'vulnerability_cwe_pkey'
 }
 
 /** input type for incrementing numeric columns in table "vulnerability.vulnerability_cwe" */
@@ -12040,6 +12365,13 @@ export type GetManifestDependencyEdgeAnalysisResultQueryVariables = Exact<{
 
 export type GetManifestDependencyEdgeAnalysisResultQuery = { __typename?: 'query_root', analysis_manifest_dependency_edge_result: Array<{ __typename?: 'analysis_manifest_dependency_edge_result', id: any, finding_type: Analysis_Finding_Type_Enum }> };
 
+export type GetManifestDependencyEdgeChildrenQueryVariables = Exact<{
+  ids: Array<Scalars['uuid']> | Scalars['uuid'];
+}>;
+
+
+export type GetManifestDependencyEdgeChildrenQuery = { __typename?: 'query_root', manifest_dependency_node: Array<{ __typename?: 'manifest_dependency_node', id: any, range: string, labels?: any | null, release_id: any, release: { __typename?: 'package_release', id: any, fetched_time?: any | null, version: string, package: { __typename?: 'package', name: string, last_successful_fetch?: any | null, package_manager: any, affected_by_vulnerability: Array<{ __typename?: 'vulnerability_affected', vulnerability: { __typename?: 'vulnerability', id: any, source_id: string, source: string, severity_name?: any | null, cvss_score?: number | null, summary?: string | null, guide_vulnerabilities: Array<{ __typename?: 'guide_vulnerabilities', guide_id: any, guide: { __typename?: 'guides', summary: string, id: any, title: string } }>, cwes: Array<{ __typename?: 'vulnerability_vulnerability_cwe', id: any, cwe: { __typename?: 'vulnerability_cwe', id: number, name: string, description: string, common_name?: string | null } }> }, ranges: Array<{ __typename?: 'vulnerability_range', introduced?: string | null, fixed?: string | null }> }> } } }> };
+
 export type GetOrganizationFromInstallationIdQueryVariables = Exact<{
   installation_id?: InputMaybe<Scalars['Int']>;
 }>;
@@ -12074,7 +12406,7 @@ export type GetTreeFromBuildQueryVariables = Exact<{
 }>;
 
 
-export type GetTreeFromBuildQuery = { __typename?: 'query_root', builds_by_pk?: { __typename?: 'builds', resolved_manifests: Array<{ __typename?: 'resolved_manifest', id: any, path?: string | null, child_edges_recursive?: Array<{ __typename?: 'manifest_dependency_edge', id: any, parent_id: any, child_id: any, analysis_results: Array<{ __typename?: 'analysis_manifest_dependency_edge_result', finding_source_version: number, finding_source: Analysis_Finding_Source_Enum, finding_type: Analysis_Finding_Type_Enum }>, child: { __typename?: 'manifest_dependency_node', id: any, range: string, labels?: any | null, release_id: any, release: { __typename?: 'package_release', id: any, fetched_time?: any | null, version: string, package: { __typename?: 'package', name: string, last_successful_fetch?: any | null, package_manager: any, affected_by_vulnerability: Array<{ __typename?: 'vulnerability_affected', vulnerability: { __typename?: 'vulnerability', id: any, source_id: string, source: string, severity_name?: any | null, cvss_score?: number | null, summary?: string | null, guide_vulnerabilities: Array<{ __typename?: 'guide_vulnerabilities', guide_id: any, guide: { __typename?: 'guides', summary: string, id: any, title: string } }>, cwes: Array<{ __typename?: 'vulnerability_vulnerability_cwe', id: any, cwe: { __typename?: 'vulnerability_cwe', id: number, name: string, description: string, common_name?: string | null } }> }, ranges: Array<{ __typename?: 'vulnerability_range', introduced?: string | null, fixed?: string | null }> }> } } } }> | null }>, project: { __typename?: 'projects', name: string, ignored_vulnerabilities: Array<{ __typename?: 'ignored_vulnerabilities', id: any, creator_id?: any | null, locations: any, note: string, project_id: any, vulnerability_id: any }> } } | null };
+export type GetTreeFromBuildQuery = { __typename?: 'query_root', builds_by_pk?: { __typename?: 'builds', resolved_manifests: Array<{ __typename?: 'resolved_manifest', id: any, path?: string | null, child_edges_recursive?: Array<{ __typename?: 'manifest_dependency_edge', id: any, parent_id: any, child_id: any, analysis_results: Array<{ __typename?: 'analysis_manifest_dependency_edge_result', finding_source_version: number, finding_source: Analysis_Finding_Source_Enum, finding_type: Analysis_Finding_Type_Enum }> }> | null }>, project: { __typename?: 'projects', name: string, ignored_vulnerabilities: Array<{ __typename?: 'ignored_vulnerabilities', id: any, creator_id?: any | null, locations: any, note: string, project_id: any, vulnerability_id: any }> } } | null };
 
 export type GetUserGitHubDataQueryVariables = Exact<{
   kratos_id?: InputMaybe<Scalars['uuid']>;
@@ -12395,6 +12727,57 @@ export const GetManifestDependencyEdgeAnalysisResultDocument = gql`
   }
 }
     `;
+export const GetManifestDependencyEdgeChildrenDocument = gql`
+    query GetManifestDependencyEdgeChildren($ids: [uuid!]!) {
+  manifest_dependency_node(where: {id: {_in: $ids}}) {
+    id
+    range
+    labels
+    release_id
+    release {
+      id
+      fetched_time
+      version
+      package {
+        name
+        last_successful_fetch
+        package_manager
+        affected_by_vulnerability {
+          vulnerability {
+            id
+            source_id
+            source
+            severity_name
+            cvss_score
+            summary
+            guide_vulnerabilities {
+              guide_id
+              guide {
+                summary
+                id
+                title
+              }
+            }
+            cwes {
+              id
+              cwe {
+                id
+                name
+                description
+                common_name
+              }
+            }
+          }
+          ranges {
+            introduced
+            fixed
+          }
+        }
+      }
+    }
+  }
+}
+    `;
 export const GetOrganizationFromInstallationIdDocument = gql`
     query GetOrganizationFromInstallationId($installation_id: Int) {
   organizations(where: {installation_id: {_eq: $installation_id}}) {
@@ -12447,53 +12830,6 @@ export const GetTreeFromBuildDocument = gql`
           finding_source_version
           finding_source
           finding_type
-        }
-        child {
-          id
-          range
-          labels
-          release_id
-          release {
-            id
-            fetched_time
-            version
-            package {
-              name
-              last_successful_fetch
-              package_manager
-              affected_by_vulnerability {
-                vulnerability {
-                  id
-                  source_id
-                  source
-                  severity_name
-                  cvss_score
-                  summary
-                  guide_vulnerabilities {
-                    guide_id
-                    guide {
-                      summary
-                      id
-                      title
-                    }
-                  }
-                  cwes {
-                    id
-                    cwe {
-                      id
-                      name
-                      description
-                      common_name
-                    }
-                  }
-                }
-                ranges {
-                  introduced
-                  fixed
-                }
-              }
-            }
-          }
         }
       }
     }
@@ -12842,6 +13178,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     GetManifestDependencyEdgeAnalysisResult(variables: GetManifestDependencyEdgeAnalysisResultQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetManifestDependencyEdgeAnalysisResultQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetManifestDependencyEdgeAnalysisResultQuery>(GetManifestDependencyEdgeAnalysisResultDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetManifestDependencyEdgeAnalysisResult', 'query');
+    },
+    GetManifestDependencyEdgeChildren(variables: GetManifestDependencyEdgeChildrenQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetManifestDependencyEdgeChildrenQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetManifestDependencyEdgeChildrenQuery>(GetManifestDependencyEdgeChildrenDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetManifestDependencyEdgeChildren', 'query');
     },
     GetOrganizationFromInstallationId(variables?: GetOrganizationFromInstallationIdQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetOrganizationFromInstallationIdQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetOrganizationFromInstallationIdQuery>(GetOrganizationFromInstallationIdDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetOrganizationFromInstallationId', 'query');

--- a/lunatrace/bsl/backend/src/hasura-api/generated.ts
+++ b/lunatrace/bsl/backend/src/hasura-api/generated.ts
@@ -8748,6 +8748,7 @@ export type Query_RootVulnerability_Vulnerability_Cwe_By_PkArgs = {
 export type Query_RootVulnerableReleasesFromBuildArgs = {
   buildId: Scalars['uuid'];
   minimumSeverity?: InputMaybe<Scalars['String']>;
+  previewChains?: InputMaybe<Scalars['Boolean']>;
 };
 
 

--- a/lunatrace/bsl/backend/src/hasura-api/graphql/get-manifest-dependency-edge-children.graphql
+++ b/lunatrace/bsl/backend/src/hasura-api/graphql/get-manifest-dependency-edge-children.graphql
@@ -1,0 +1,49 @@
+query GetManifestDependencyEdgeChildren($ids: [uuid!]!) {
+  manifest_dependency_node(where: {id: {_in: $ids}}) {
+    id
+    range
+    labels
+    release_id
+    release {
+      id
+      fetched_time
+      version
+      package {
+        name
+        last_successful_fetch
+        package_manager
+        affected_by_vulnerability {
+          vulnerability {
+            id
+            source_id
+            source
+            severity_name
+            cvss_score
+            summary
+            guide_vulnerabilities {
+              guide_id
+              guide {
+                summary
+                id
+                title
+              }
+            }
+            cwes {
+              id
+              cwe {
+                id
+                name
+                description
+                common_name
+              }
+            }
+          }
+          ranges {
+            introduced
+            fixed
+          }
+        }
+      }
+    }
+  }
+}

--- a/lunatrace/bsl/backend/src/hasura-api/graphql/get-tree-from-build.graphql
+++ b/lunatrace/bsl/backend/src/hasura-api/graphql/get-tree-from-build.graphql
@@ -12,53 +12,6 @@ query GetTreeFromBuild($build_id: uuid!, $analysis_results_where: analysis_manif
                   finding_source
                   finding_type
                 }
-                child {
-                    id
-                    range
-                    labels
-                    release_id
-                    release {
-                        id
-                        fetched_time
-                        version
-                        package {
-                            name
-                            last_successful_fetch
-                            package_manager
-                            affected_by_vulnerability {
-                                vulnerability {
-                                    id
-                                    source_id
-                                    source
-                                    severity_name
-                                    cvss_score
-                                    summary
-                                    guide_vulnerabilities {
-                                        guide_id
-                                        guide {
-                                            summary
-                                            id
-                                            title
-                                        }
-                                    }
-                                    cwes {
-                                        id
-                                        cwe {
-                                            id
-                                            name
-                                            description
-                                            common_name
-                                        }
-                                    }
-                                }
-                                ranges {
-                                    introduced
-                                    fixed
-                                }
-                            }
-                        }
-                    }
-                }
             }
         }
         project {

--- a/lunatrace/bsl/backend/src/models/vulnerability-dependency-tree/index.ts
+++ b/lunatrace/bsl/backend/src/models/vulnerability-dependency-tree/index.ts
@@ -12,12 +12,11 @@
  *
  */
 import { randomUUID } from 'crypto';
-import util from 'util';
 
 import { SeverityNamesOsv } from '@lunatrace/lunatrace-common/build/main';
 
 import { Analysis_Finding_Type_Enum } from '../../hasura-api/generated';
-import { log } from '../../utils/log';
+import { newBenchmarkTable, start } from '../../utils/performance';
 import { notEmpty } from '../../utils/predicates';
 
 import { Graph } from './graph';
@@ -141,7 +140,53 @@ export default class VulnerabilityDependencyTree {
     return vulnerableEdges;
   }
 
-  public getVulnerableReleases(): VulnerableRelease[] {
+  private getVulnerableDependencyChainsForNode(nodeId: string, singleReachableChain?: boolean): DependencyChain[] {
+    const chainIdStrings = this.allDependencyPathsToNodeId(nodeId);
+
+    let addedReachableChain = false;
+    let addedNotReachableChain = false;
+    const dependencyChains: DependencyChain[] = [];
+    for (const chain of chainIdStrings) {
+      const depChain = chain
+        .map((nodeId) => {
+          const node = this.nodeIdToNode.get(nodeId);
+          const reachable = this.nodeReachability.get(nodeId);
+          if (!node) {
+            return null;
+          }
+          return {
+            ...node,
+            reachable: reachable || Analysis_Finding_Type_Enum.Unknown,
+          };
+        })
+        .filter(notEmpty);
+
+      const isNotReachableChain = !depChain.some((d) => d.reachable === Analysis_Finding_Type_Enum.NotVulnerable);
+
+      /*
+       If we only want to show a single chain to demonstrate the capabilities of the dependency chain view, then we
+        1) determine if the chain is reachable or not
+        2) see if we have added a reachable/non-reachable chain already
+        3) once we have added both types of chains, then return to save some time
+       */
+      if (singleReachableChain) {
+        if (isNotReachableChain && !addedNotReachableChain) {
+          dependencyChains.push(depChain);
+          addedNotReachableChain = true;
+        }
+        if (!isNotReachableChain && !addedReachableChain) {
+          dependencyChains.push(depChain);
+          addedReachableChain = true;
+        }
+        if (addedReachableChain && addedNotReachableChain) {
+          return dependencyChains;
+        }
+      }
+    }
+    return dependencyChains;
+  }
+
+  public getVulnerableReleases(singleReachableChain?: boolean): VulnerableRelease[] {
     const vulnerableReleasesById: Map<string, VulnerableRelease> = new Map();
 
     this.vulnerableNodeIds.forEach((nodeId) => {
@@ -155,35 +200,18 @@ export default class VulnerabilityDependencyTree {
         return;
       }
 
-      const chainIdStrings = this.allDependencyPathsToNodeId(nodeId);
+      const triviallyUpdatable = isReleaseTriviallyUpdateable(packageReleaseVulnerabilities);
 
-      // TODO (cthompson) we should be able to respond with just the node ids for the chain
-      // all nodes should be sent back as an array
-      const chains: DependencyChain[] = chainIdStrings.map((chain) => {
-        return chain
-          .map((nodeId) => {
-            const node = this.nodeIdToNode.get(nodeId);
-            const reachable = this.nodeReachability.get(nodeId);
-            if (!node) {
-              return null;
-            }
-            return {
-              ...node,
-              reachable: reachable || Analysis_Finding_Type_Enum.Unknown,
-            };
-          })
-          .filter(notEmpty);
-      });
+      const chains = this.getVulnerableDependencyChainsForNode(nodeId, singleReachableChain);
 
-      const devOnly = chainIdStrings.every((chain) => {
-        const node = this.nodeIdToNode.get(chain[0]);
-        if (!node) {
+      const devOnly = chains.every((chain) => {
+        if (chain.length === 0) {
           return false;
         }
+
+        const node = chain[0];
         return node.labels && node.labels.scope === 'dev';
       });
-
-      const triviallyUpdatable = isReleaseTriviallyUpdateable(packageReleaseVulnerabilities);
 
       // loop each vulnerability on the node
       packageReleaseVulnerabilities.forEach((releaseVulnerability, index) => {

--- a/lunatrace/bsl/backend/src/models/vulnerability-dependency-tree/index.ts
+++ b/lunatrace/bsl/backend/src/models/vulnerability-dependency-tree/index.ts
@@ -16,7 +16,6 @@ import { randomUUID } from 'crypto';
 import { SeverityNamesOsv } from '@lunatrace/lunatrace-common/build/main';
 
 import { Analysis_Finding_Type_Enum } from '../../hasura-api/generated';
-import { newBenchmarkTable, start } from '../../utils/performance';
 import { notEmpty } from '../../utils/predicates';
 
 import { Graph } from './graph';

--- a/lunatrace/bsl/backend/src/models/vulnerability-dependency-tree/index.ts
+++ b/lunatrace/bsl/backend/src/models/vulnerability-dependency-tree/index.ts
@@ -139,14 +139,11 @@ export default class VulnerabilityDependencyTree {
     return vulnerableEdges;
   }
 
-  private getVulnerableDependencyChainsForNode(nodeId: string, singleReachableChain?: boolean): DependencyChain[] {
+  private getVulnerableDependencyChainsForNode(nodeId: string): DependencyChain[] {
     const chainIdStrings = this.allDependencyPathsToNodeId(nodeId);
 
-    let addedReachableChain = false;
-    let addedNotReachableChain = false;
-    const dependencyChains: DependencyChain[] = [];
-    for (const chain of chainIdStrings) {
-      const depChain = chain
+    return chainIdStrings.map((chain) => {
+      return chain
         .map((nodeId) => {
           const node = this.nodeIdToNode.get(nodeId);
           const reachable = this.nodeReachability.get(nodeId);
@@ -159,8 +156,16 @@ export default class VulnerabilityDependencyTree {
           };
         })
         .filter(notEmpty);
+    });
+  }
 
-      const isNotReachableChain = !depChain.some((d) => d.reachable === Analysis_Finding_Type_Enum.NotVulnerable);
+  private createDependencyChainPreview(chains: DependencyChain[]) {
+    const dependencyChains: DependencyChain[] = [];
+
+    let addedReachableChain = false;
+    let addedNotReachableChain = false;
+    for (const chain of chains) {
+      const isNotReachableChain = !chain.some((d) => d.reachable === Analysis_Finding_Type_Enum.NotVulnerable);
 
       /*
        If we only want to show a single chain to demonstrate the capabilities of the dependency chain view, then we
@@ -168,24 +173,22 @@ export default class VulnerabilityDependencyTree {
         2) see if we have added a reachable/non-reachable chain already
         3) once we have added both types of chains, then return to save some time
        */
-      if (singleReachableChain) {
-        if (isNotReachableChain && !addedNotReachableChain) {
-          dependencyChains.push(depChain);
-          addedNotReachableChain = true;
-        }
-        if (!isNotReachableChain && !addedReachableChain) {
-          dependencyChains.push(depChain);
-          addedReachableChain = true;
-        }
-        if (addedReachableChain && addedNotReachableChain) {
-          return dependencyChains;
-        }
+      if (isNotReachableChain && !addedNotReachableChain) {
+        dependencyChains.push(chain);
+        addedNotReachableChain = true;
+      }
+      if (!isNotReachableChain && !addedReachableChain) {
+        dependencyChains.push(chain);
+        addedReachableChain = true;
+      }
+      if (addedReachableChain && addedNotReachableChain) {
+        return dependencyChains;
       }
     }
     return dependencyChains;
   }
 
-  public getVulnerableReleases(singleReachableChain?: boolean): VulnerableRelease[] {
+  public getVulnerableReleases(previewChains?: boolean): VulnerableRelease[] {
     const vulnerableReleasesById: Map<string, VulnerableRelease> = new Map();
 
     this.vulnerableNodeIds.forEach((nodeId) => {
@@ -201,7 +204,8 @@ export default class VulnerabilityDependencyTree {
 
       const triviallyUpdatable = isReleaseTriviallyUpdateable(packageReleaseVulnerabilities);
 
-      const chains = this.getVulnerableDependencyChainsForNode(nodeId, singleReachableChain);
+      const depChains = this.getVulnerableDependencyChainsForNode(nodeId);
+      const chains = previewChains ? this.createDependencyChainPreview(depChains) : depChains;
 
       const devOnly = chains.every((chain) => {
         if (chain.length === 0) {

--- a/lunatrace/bsl/backend/src/models/vulnerability-dependency-tree/vulnerability-tree-from-hasura.ts
+++ b/lunatrace/bsl/backend/src/models/vulnerability-dependency-tree/vulnerability-tree-from-hasura.ts
@@ -1,0 +1,87 @@
+import { LunaLogger } from '@lunatrace/logger/build/main';
+import { SeverityNamesOsv } from '@lunatrace/lunatrace-common/src/types';
+
+import { hasura } from '../../hasura-api';
+import { MaybeError } from '../../types/util';
+import { newError, newResult } from '../../utils/errors';
+import { notEmpty } from '../../utils/predicates';
+
+import { Manifest, ManifestEdge, ManifestNode } from './types';
+
+import VulnerabilityDependencyTree from './index';
+
+export async function vulnerabilityTreeFromHasura(
+  logger: LunaLogger,
+  buildId: string,
+  minimumSeverity?: SeverityNamesOsv
+): Promise<MaybeError<VulnerabilityDependencyTree>> {
+  const { builds_by_pk: rawBuildData } = await hasura.GetTreeFromBuild({
+    build_id: buildId,
+  });
+
+  if (!rawBuildData) {
+    return newError('unable to query build data from hasura');
+  }
+
+  const rawManifests = rawBuildData.resolved_manifests;
+
+  const ignoredVulnerabilities = rawBuildData.project.ignored_vulnerabilities;
+
+  const uniqueChildIds = new Set<string>();
+  rawManifests.forEach((m) => {
+    m.child_edges_recursive?.forEach((c) => {
+      uniqueChildIds.add(c.child_id);
+    });
+  });
+
+  const childIdList = [...uniqueChildIds.values()];
+
+  logger.info('collecting child information', {
+    childrenCount: childIdList.length,
+  });
+
+  const { manifest_dependency_node: childrenInfo } = await hasura.GetManifestDependencyEdgeChildren({
+    ids: childIdList,
+  });
+
+  const childInfoLookup = new Map<string, ManifestNode>();
+  childrenInfo.forEach((c) => {
+    childInfoLookup.set(c.id, c);
+  });
+
+  const manifests: Array<Manifest> = rawManifests
+    .map((m) => {
+      return {
+        ...m,
+        child_edges_recursive: m.child_edges_recursive
+          ?.map((c): ManifestEdge | undefined => {
+            const child = childInfoLookup.get(c.child_id);
+            if (!child) {
+              return undefined;
+            }
+            return {
+              ...c,
+              child,
+            };
+          })
+          .filter(notEmpty),
+      };
+    })
+    .filter(notEmpty);
+
+  logger.info('building tree', {
+    childrenInfo: childrenInfo.length,
+    manifests: manifests.length,
+  });
+
+  if (!manifests || manifests.length === 0) {
+    return newError('no manifest data to build tree from');
+  }
+
+  const depTree = new VulnerabilityDependencyTree(manifests, ignoredVulnerabilities, minimumSeverity);
+  if (!depTree) {
+    // tells the client that we didnt get any tree info back and to fall back to grype (for now)
+    return newError('unable to build dependency tree');
+  }
+  return newResult(depTree);
+}

--- a/lunatrace/bsl/backend/src/utils/performance.ts
+++ b/lunatrace/bsl/backend/src/utils/performance.ts
@@ -1,0 +1,17 @@
+export function newBenchmarkTable(): Map<string, number> {
+  return new Map<string, number>();
+}
+
+export const start = (tag?: string, bench?: Map<string, number>) => {
+  const startTime = new Date().getMilliseconds();
+  return () => {
+    const endTime = new Date().getMilliseconds();
+    const delta = endTime - startTime;
+
+    if (tag !== undefined && bench !== undefined) {
+      const perf = bench.get(tag);
+      bench.set(tag, (perf || 0) + delta);
+    }
+    return delta;
+  };
+};

--- a/lunatrace/bsl/backend/src/workers/queue/activities/scan-snapshot-activity.ts
+++ b/lunatrace/bsl/backend/src/workers/queue/activities/scan-snapshot-activity.ts
@@ -23,7 +23,6 @@ import { hasura } from '../../../hasura-api';
 import { updateBuildStatus } from '../../../hasura-api/actions/update-build-status';
 import { updateManifestStatus } from '../../../hasura-api/actions/update-manifest-status';
 import { Build_State_Enum } from '../../../hasura-api/generated';
-import VulnerabilityDependencyTree from '../../../models/vulnerability-dependency-tree';
 import { vulnerabilityTreeFromHasura } from '../../../models/vulnerability-dependency-tree/vulnerability-tree-from-hasura';
 import { S3ObjectMetadata } from '../../../types/s3';
 import { SbomBucketInfo } from '../../../types/scan';

--- a/lunatrace/bsl/frontend/src/api/generated.ts
+++ b/lunatrace/bsl/frontend/src/api/generated.ts
@@ -5485,6 +5485,7 @@ export type Query_RootVulnerability_Vulnerability_Cwe_By_PkArgs = {
 export type Query_RootVulnerableReleasesFromBuildArgs = {
   buildId: Scalars['uuid'];
   minimumSeverity?: InputMaybe<Scalars['String']>;
+  previewChains?: InputMaybe<Scalars['Boolean']>;
 };
 
 /** Boolean expression to compare columns of type "reference_type". All fields are combined with logical 'AND'. */
@@ -8002,6 +8003,7 @@ export type GetVulnerabilityDetailsQuery = { __typename?: 'query_root', vulnerab
 export type GetVulnerableReleasesFromBuildQueryVariables = Exact<{
   buildId: Scalars['uuid'];
   minimumSeverity: Scalars['String'];
+  previewChains?: InputMaybe<Scalars['Boolean']>;
 }>;
 
 
@@ -8765,10 +8767,11 @@ export const GetVulnerabilityDetailsDocument = `
 }
     `;
 export const GetVulnerableReleasesFromBuildDocument = `
-    query GetVulnerableReleasesFromBuild($buildId: uuid!, $minimumSeverity: String!) {
+    query GetVulnerableReleasesFromBuild($buildId: uuid!, $minimumSeverity: String!, $previewChains: Boolean) {
   vulnerableReleasesFromBuild(
     buildId: $buildId
     minimumSeverity: $minimumSeverity
+    previewChains: $previewChains
   ) {
     trivially_updatable
     beneath_minimum_severity

--- a/lunatrace/bsl/frontend/src/api/generated.ts
+++ b/lunatrace/bsl/frontend/src/api/generated.ts
@@ -60,7 +60,7 @@ export type BuildData_AffectedByVulnerability = {
 
 export type BuildData_Cwe = {
   __typename?: 'BuildData_Cwe';
-  common_name: Scalars['String'];
+  common_name?: Maybe<Scalars['String']>;
   description: Scalars['String'];
   id: Scalars['Int'];
   name: Scalars['String'];
@@ -318,6 +318,10 @@ export type Analysis_Manifest_Dependency_Edge_Result = {
   finding_source_version: Scalars['Int'];
   finding_type: Analysis_Finding_Type_Enum;
   id: Scalars['uuid'];
+  /** An array relationship */
+  locations: Array<Analysis_Manifest_Dependency_Edge_Result_Location>;
+  /** An aggregate relationship */
+  locations_aggregate: Analysis_Manifest_Dependency_Edge_Result_Location_Aggregate;
   /** An object relationship */
   manifest_dependency_edge: Manifest_Dependency_Edge;
   manifest_dependency_edge_id: Scalars['uuid'];
@@ -325,6 +329,26 @@ export type Analysis_Manifest_Dependency_Edge_Result = {
   /** An object relationship */
   vulnerability: Vulnerability;
   vulnerability_id: Scalars['uuid'];
+};
+
+
+/** columns and relationships of "analysis.manifest_dependency_edge_result" */
+export type Analysis_Manifest_Dependency_Edge_ResultLocationsArgs = {
+  distinct_on?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Order_By>>;
+  where?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp>;
+};
+
+
+/** columns and relationships of "analysis.manifest_dependency_edge_result" */
+export type Analysis_Manifest_Dependency_Edge_ResultLocations_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Order_By>>;
+  where?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp>;
 };
 
 
@@ -399,11 +423,294 @@ export type Analysis_Manifest_Dependency_Edge_Result_Bool_Exp = {
   finding_source_version?: InputMaybe<Int_Comparison_Exp>;
   finding_type?: InputMaybe<Analysis_Finding_Type_Enum_Comparison_Exp>;
   id?: InputMaybe<Uuid_Comparison_Exp>;
+  locations?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp>;
   manifest_dependency_edge?: InputMaybe<Manifest_Dependency_Edge_Bool_Exp>;
   manifest_dependency_edge_id?: InputMaybe<Uuid_Comparison_Exp>;
   output?: InputMaybe<Jsonb_Comparison_Exp>;
   vulnerability?: InputMaybe<Vulnerability_Bool_Exp>;
   vulnerability_id?: InputMaybe<Uuid_Comparison_Exp>;
+};
+
+/** Callsite of a child dependency being imported and used inside of a parent manifest dependency. */
+export type Analysis_Manifest_Dependency_Edge_Result_Location = {
+  __typename?: 'analysis_manifest_dependency_edge_result_location';
+  end_column: Scalars['Int'];
+  end_row: Scalars['Int'];
+  id: Scalars['uuid'];
+  manifest_dependency_edge_result_id: Scalars['uuid'];
+  path: Scalars['String'];
+  start_column: Scalars['Int'];
+  start_row: Scalars['Int'];
+};
+
+/** aggregated selection of "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Aggregate = {
+  __typename?: 'analysis_manifest_dependency_edge_result_location_aggregate';
+  aggregate?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Location_Aggregate_Fields>;
+  nodes: Array<Analysis_Manifest_Dependency_Edge_Result_Location>;
+};
+
+/** aggregate fields of "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Aggregate_Fields = {
+  __typename?: 'analysis_manifest_dependency_edge_result_location_aggregate_fields';
+  avg?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Location_Avg_Fields>;
+  count: Scalars['Int'];
+  max?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Location_Max_Fields>;
+  min?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Location_Min_Fields>;
+  stddev?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Location_Stddev_Fields>;
+  stddev_pop?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Location_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Location_Stddev_Samp_Fields>;
+  sum?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Location_Sum_Fields>;
+  var_pop?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Location_Var_Pop_Fields>;
+  var_samp?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Location_Var_Samp_Fields>;
+  variance?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Location_Variance_Fields>;
+};
+
+
+/** aggregate fields of "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']>;
+};
+
+/** order by aggregate values of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Aggregate_Order_By = {
+  avg?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Avg_Order_By>;
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Max_Order_By>;
+  min?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Min_Order_By>;
+  stddev?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Stddev_Order_By>;
+  stddev_pop?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Stddev_Pop_Order_By>;
+  stddev_samp?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Stddev_Samp_Order_By>;
+  sum?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Sum_Order_By>;
+  var_pop?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Var_Pop_Order_By>;
+  var_samp?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Var_Samp_Order_By>;
+  variance?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Variance_Order_By>;
+};
+
+/** aggregate avg on columns */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Avg_Fields = {
+  __typename?: 'analysis_manifest_dependency_edge_result_location_avg_fields';
+  end_column?: Maybe<Scalars['Float']>;
+  end_row?: Maybe<Scalars['Float']>;
+  start_column?: Maybe<Scalars['Float']>;
+  start_row?: Maybe<Scalars['Float']>;
+};
+
+/** order by avg() on columns of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Avg_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
+};
+
+/** Boolean expression to filter rows from the table "analysis.manifest_dependency_edge_result_location". All fields are combined with a logical 'AND'. */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp = {
+  _and?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp>>;
+  _not?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp>;
+  _or?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp>>;
+  end_column?: InputMaybe<Int_Comparison_Exp>;
+  end_row?: InputMaybe<Int_Comparison_Exp>;
+  id?: InputMaybe<Uuid_Comparison_Exp>;
+  manifest_dependency_edge_result_id?: InputMaybe<Uuid_Comparison_Exp>;
+  path?: InputMaybe<String_Comparison_Exp>;
+  start_column?: InputMaybe<Int_Comparison_Exp>;
+  start_row?: InputMaybe<Int_Comparison_Exp>;
+};
+
+/** aggregate max on columns */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Max_Fields = {
+  __typename?: 'analysis_manifest_dependency_edge_result_location_max_fields';
+  end_column?: Maybe<Scalars['Int']>;
+  end_row?: Maybe<Scalars['Int']>;
+  id?: Maybe<Scalars['uuid']>;
+  manifest_dependency_edge_result_id?: Maybe<Scalars['uuid']>;
+  path?: Maybe<Scalars['String']>;
+  start_column?: Maybe<Scalars['Int']>;
+  start_row?: Maybe<Scalars['Int']>;
+};
+
+/** order by max() on columns of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Max_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  manifest_dependency_edge_result_id?: InputMaybe<Order_By>;
+  path?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Min_Fields = {
+  __typename?: 'analysis_manifest_dependency_edge_result_location_min_fields';
+  end_column?: Maybe<Scalars['Int']>;
+  end_row?: Maybe<Scalars['Int']>;
+  id?: Maybe<Scalars['uuid']>;
+  manifest_dependency_edge_result_id?: Maybe<Scalars['uuid']>;
+  path?: Maybe<Scalars['String']>;
+  start_column?: Maybe<Scalars['Int']>;
+  start_row?: Maybe<Scalars['Int']>;
+};
+
+/** order by min() on columns of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Min_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  manifest_dependency_edge_result_id?: InputMaybe<Order_By>;
+  path?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
+};
+
+/** Ordering options when selecting data from "analysis.manifest_dependency_edge_result_location". */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  manifest_dependency_edge_result_id?: InputMaybe<Order_By>;
+  path?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
+};
+
+/** select columns of table "analysis.manifest_dependency_edge_result_location" */
+export enum Analysis_Manifest_Dependency_Edge_Result_Location_Select_Column {
+  /** column name */
+  EndColumn = 'end_column',
+  /** column name */
+  EndRow = 'end_row',
+  /** column name */
+  Id = 'id',
+  /** column name */
+  ManifestDependencyEdgeResultId = 'manifest_dependency_edge_result_id',
+  /** column name */
+  Path = 'path',
+  /** column name */
+  StartColumn = 'start_column',
+  /** column name */
+  StartRow = 'start_row'
+}
+
+/** aggregate stddev on columns */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Stddev_Fields = {
+  __typename?: 'analysis_manifest_dependency_edge_result_location_stddev_fields';
+  end_column?: Maybe<Scalars['Float']>;
+  end_row?: Maybe<Scalars['Float']>;
+  start_column?: Maybe<Scalars['Float']>;
+  start_row?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev() on columns of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Stddev_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Stddev_Pop_Fields = {
+  __typename?: 'analysis_manifest_dependency_edge_result_location_stddev_pop_fields';
+  end_column?: Maybe<Scalars['Float']>;
+  end_row?: Maybe<Scalars['Float']>;
+  start_column?: Maybe<Scalars['Float']>;
+  start_row?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_pop() on columns of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Stddev_Pop_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Stddev_Samp_Fields = {
+  __typename?: 'analysis_manifest_dependency_edge_result_location_stddev_samp_fields';
+  end_column?: Maybe<Scalars['Float']>;
+  end_row?: Maybe<Scalars['Float']>;
+  start_column?: Maybe<Scalars['Float']>;
+  start_row?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_samp() on columns of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Stddev_Samp_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
+};
+
+/** aggregate sum on columns */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Sum_Fields = {
+  __typename?: 'analysis_manifest_dependency_edge_result_location_sum_fields';
+  end_column?: Maybe<Scalars['Int']>;
+  end_row?: Maybe<Scalars['Int']>;
+  start_column?: Maybe<Scalars['Int']>;
+  start_row?: Maybe<Scalars['Int']>;
+};
+
+/** order by sum() on columns of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Sum_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_pop on columns */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Var_Pop_Fields = {
+  __typename?: 'analysis_manifest_dependency_edge_result_location_var_pop_fields';
+  end_column?: Maybe<Scalars['Float']>;
+  end_row?: Maybe<Scalars['Float']>;
+  start_column?: Maybe<Scalars['Float']>;
+  start_row?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_pop() on columns of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Var_Pop_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Var_Samp_Fields = {
+  __typename?: 'analysis_manifest_dependency_edge_result_location_var_samp_fields';
+  end_column?: Maybe<Scalars['Float']>;
+  end_row?: Maybe<Scalars['Float']>;
+  start_column?: Maybe<Scalars['Float']>;
+  start_row?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_samp() on columns of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Var_Samp_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Variance_Fields = {
+  __typename?: 'analysis_manifest_dependency_edge_result_location_variance_fields';
+  end_column?: Maybe<Scalars['Float']>;
+  end_row?: Maybe<Scalars['Float']>;
+  start_column?: Maybe<Scalars['Float']>;
+  start_row?: Maybe<Scalars['Float']>;
+};
+
+/** order by variance() on columns of table "analysis.manifest_dependency_edge_result_location" */
+export type Analysis_Manifest_Dependency_Edge_Result_Location_Variance_Order_By = {
+  end_column?: InputMaybe<Order_By>;
+  end_row?: InputMaybe<Order_By>;
+  start_column?: InputMaybe<Order_By>;
+  start_row?: InputMaybe<Order_By>;
 };
 
 /** aggregate max on columns */
@@ -451,6 +758,7 @@ export type Analysis_Manifest_Dependency_Edge_Result_Order_By = {
   finding_source_version?: InputMaybe<Order_By>;
   finding_type?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
+  locations_aggregate?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Aggregate_Order_By>;
   manifest_dependency_edge?: InputMaybe<Manifest_Dependency_Edge_Order_By>;
   manifest_dependency_edge_id?: InputMaybe<Order_By>;
   output?: InputMaybe<Order_By>;
@@ -4392,6 +4700,12 @@ export type Query_Root = {
   analysis_manifest_dependency_edge_result_aggregate: Analysis_Manifest_Dependency_Edge_Result_Aggregate;
   /** fetch data from the table: "analysis.manifest_dependency_edge_result" using primary key columns */
   analysis_manifest_dependency_edge_result_by_pk?: Maybe<Analysis_Manifest_Dependency_Edge_Result>;
+  /** fetch data from the table: "analysis.manifest_dependency_edge_result_location" */
+  analysis_manifest_dependency_edge_result_location: Array<Analysis_Manifest_Dependency_Edge_Result_Location>;
+  /** fetch aggregated fields from the table: "analysis.manifest_dependency_edge_result_location" */
+  analysis_manifest_dependency_edge_result_location_aggregate: Analysis_Manifest_Dependency_Edge_Result_Location_Aggregate;
+  /** fetch data from the table: "analysis.manifest_dependency_edge_result_location" using primary key columns */
+  analysis_manifest_dependency_edge_result_location_by_pk?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Location>;
   authenticatedRepoCloneUrl?: Maybe<AuthenticatedRepoCloneUrlOutput>;
   availableOrgsWithRepos?: Maybe<Array<OrgWithRepos>>;
   /** fetch data from the table: "build_dependency_relationship" */
@@ -4573,6 +4887,29 @@ export type Query_RootAnalysis_Manifest_Dependency_Edge_Result_AggregateArgs = {
 
 
 export type Query_RootAnalysis_Manifest_Dependency_Edge_Result_By_PkArgs = {
+  id: Scalars['uuid'];
+};
+
+
+export type Query_RootAnalysis_Manifest_Dependency_Edge_Result_LocationArgs = {
+  distinct_on?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Order_By>>;
+  where?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp>;
+};
+
+
+export type Query_RootAnalysis_Manifest_Dependency_Edge_Result_Location_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Order_By>>;
+  where?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp>;
+};
+
+
+export type Query_RootAnalysis_Manifest_Dependency_Edge_Result_Location_By_PkArgs = {
   id: Scalars['uuid'];
 };
 
@@ -5638,6 +5975,12 @@ export type Subscription_Root = {
   analysis_manifest_dependency_edge_result_aggregate: Analysis_Manifest_Dependency_Edge_Result_Aggregate;
   /** fetch data from the table: "analysis.manifest_dependency_edge_result" using primary key columns */
   analysis_manifest_dependency_edge_result_by_pk?: Maybe<Analysis_Manifest_Dependency_Edge_Result>;
+  /** fetch data from the table: "analysis.manifest_dependency_edge_result_location" */
+  analysis_manifest_dependency_edge_result_location: Array<Analysis_Manifest_Dependency_Edge_Result_Location>;
+  /** fetch aggregated fields from the table: "analysis.manifest_dependency_edge_result_location" */
+  analysis_manifest_dependency_edge_result_location_aggregate: Analysis_Manifest_Dependency_Edge_Result_Location_Aggregate;
+  /** fetch data from the table: "analysis.manifest_dependency_edge_result_location" using primary key columns */
+  analysis_manifest_dependency_edge_result_location_by_pk?: Maybe<Analysis_Manifest_Dependency_Edge_Result_Location>;
   /** fetch data from the table: "build_dependency_relationship" */
   build_dependency_relationship: Array<Build_Dependency_Relationship>;
   /** fetch data from the table: "build_dependency_relationship" using primary key columns */
@@ -5812,6 +6155,29 @@ export type Subscription_RootAnalysis_Manifest_Dependency_Edge_Result_AggregateA
 
 
 export type Subscription_RootAnalysis_Manifest_Dependency_Edge_Result_By_PkArgs = {
+  id: Scalars['uuid'];
+};
+
+
+export type Subscription_RootAnalysis_Manifest_Dependency_Edge_Result_LocationArgs = {
+  distinct_on?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Order_By>>;
+  where?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp>;
+};
+
+
+export type Subscription_RootAnalysis_Manifest_Dependency_Edge_Result_Location_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<Analysis_Manifest_Dependency_Edge_Result_Location_Order_By>>;
+  where?: InputMaybe<Analysis_Manifest_Dependency_Edge_Result_Location_Bool_Exp>;
+};
+
+
+export type Subscription_RootAnalysis_Manifest_Dependency_Edge_Result_Location_By_PkArgs = {
   id: Scalars['uuid'];
 };
 
@@ -7639,7 +8005,7 @@ export type GetVulnerableReleasesFromBuildQueryVariables = Exact<{
 }>;
 
 
-export type GetVulnerableReleasesFromBuildQuery = { __typename?: 'query_root', vulnerableReleasesFromBuild?: Array<{ __typename?: 'BuildData_VulnerableRelease', trivially_updatable: string, beneath_minimum_severity: boolean, cvss?: number | null, severity: string, paths: Array<string>, fix_versions: Array<string>, dev_only: boolean, guides: Array<{ __typename?: 'BuildData_Guide', id: string, title: string, summary: string }>, chains: Array<Array<{ __typename?: 'BuildData_DependencyNode', id: string, range: string, reachable: string, release: { __typename?: 'BuildData_Release', id: string, version: string, package: { __typename?: 'BuildData_Package', name: string } } }>>, release: { __typename?: 'BuildData_Release', version: string, id: string, package: { __typename?: 'BuildData_Package', name: string, package_manager: string } }, affected_by: Array<{ __typename?: 'BuildData_AffectedByVulnerability', trivially_updatable_to?: string | null, beneath_minimum_severity: boolean, fix_versions: Array<string>, path: string, ignored: boolean, ignored_vulnerability?: { __typename?: 'BuildData_IgnoredVulnerability', locations: Array<string>, note: string } | null, vulnerability: { __typename?: 'BuildData_Vulnerability', severity_name?: string | null, cvss_score?: number | null, source: string, summary?: string | null, id: string, source_id: string, guide_vulnerabilities: Array<{ __typename?: 'BuildData_Guide_Vulnerability', guide?: { __typename?: 'BuildData_Guide', id: string, summary: string, title: string } | null }>, cwes: Array<{ __typename?: 'BuildData_VulnerabilityCwe', id: string, cwe: { __typename?: 'BuildData_Cwe', id: number, name: string, description: string, common_name: string } }> } }> }> | null };
+export type GetVulnerableReleasesFromBuildQuery = { __typename?: 'query_root', vulnerableReleasesFromBuild?: Array<{ __typename?: 'BuildData_VulnerableRelease', trivially_updatable: string, beneath_minimum_severity: boolean, cvss?: number | null, severity: string, paths: Array<string>, fix_versions: Array<string>, dev_only: boolean, guides: Array<{ __typename?: 'BuildData_Guide', id: string, title: string, summary: string }>, chains: Array<Array<{ __typename?: 'BuildData_DependencyNode', id: string, range: string, reachable: string, release: { __typename?: 'BuildData_Release', id: string, version: string, package: { __typename?: 'BuildData_Package', name: string } } }>>, release: { __typename?: 'BuildData_Release', version: string, id: string, package: { __typename?: 'BuildData_Package', name: string, package_manager: string } }, affected_by: Array<{ __typename?: 'BuildData_AffectedByVulnerability', trivially_updatable_to?: string | null, beneath_minimum_severity: boolean, fix_versions: Array<string>, path: string, ignored: boolean, ignored_vulnerability?: { __typename?: 'BuildData_IgnoredVulnerability', locations: Array<string>, note: string } | null, vulnerability: { __typename?: 'BuildData_Vulnerability', severity_name?: string | null, cvss_score?: number | null, source: string, summary?: string | null, id: string, source_id: string, guide_vulnerabilities: Array<{ __typename?: 'BuildData_Guide_Vulnerability', guide?: { __typename?: 'BuildData_Guide', id: string, summary: string, title: string } | null }>, cwes: Array<{ __typename?: 'BuildData_VulnerabilityCwe', id: string, cwe: { __typename?: 'BuildData_Cwe', id: number, name: string, description: string, common_name?: string | null } }> } }> }> | null };
 
 export type InsertNewOrgUserMutationVariables = Exact<{
   organization_id: Scalars['uuid'];

--- a/lunatrace/bsl/frontend/src/api/graphql/getVulnerableReleasesFromBuild.graphql
+++ b/lunatrace/bsl/frontend/src/api/graphql/getVulnerableReleasesFromBuild.graphql
@@ -1,5 +1,5 @@
-query GetVulnerableReleasesFromBuild($buildId: uuid!, $minimumSeverity: String!) {
-    vulnerableReleasesFromBuild(buildId: $buildId, minimumSeverity: $minimumSeverity) {
+query GetVulnerableReleasesFromBuild($buildId: uuid!, $minimumSeverity: String!, $previewChains: Boolean) {
+    vulnerableReleasesFromBuild(buildId: $buildId, minimumSeverity: $minimumSeverity, previewChains: $previewChains) {
         trivially_updatable
         beneath_minimum_severity
         cvss

--- a/lunatrace/bsl/frontend/src/pages/project/builds/details/VulnerablePackageListWrapper.tsx
+++ b/lunatrace/bsl/frontend/src/pages/project/builds/details/VulnerablePackageListWrapper.tsx
@@ -33,13 +33,17 @@ export interface VulnerablePackageListWrapperProps {
 }
 
 // This component will switch between legacy views or the newer tree-based view if data is available
-export const VulnerablePackageListWrapper: React.FunctionComponent<VulnerablePackageListWrapperProps> = (
-  props: VulnerablePackageListWrapperProps
-) => {
-  const { findings, quickViewConfig, projectId, toggleIgnoreFindings, buildId, shouldIgnore } = props;
-
+export const VulnerablePackageListWrapper: React.FC<VulnerablePackageListWrapperProps> = ({
+  findings,
+  quickViewConfig,
+  projectId,
+  toggleIgnoreFindings,
+  buildId,
+  shouldIgnore,
+}) => {
   // severity state for modern tree data, legacy has its own state and doesnt use this
   const [severity, setSeverity] = useState<SeverityNamesOsv>('Critical');
+  const [showCompleteAnalysis, setShowCompleteAnalysis] = useState<boolean>(false);
 
   // data for modern tree, legacy doesnt use this
   const {
@@ -49,6 +53,7 @@ export const VulnerablePackageListWrapper: React.FunctionComponent<VulnerablePac
   } = api.useGetVulnerableReleasesFromBuildQuery({
     buildId,
     minimumSeverity: severity,
+    previewChains: !showCompleteAnalysis,
   });
 
   const unfilteredVulnerableReleasesFromTree = vulnerableReleasesData?.vulnerableReleasesFromBuild;
@@ -65,6 +70,7 @@ export const VulnerablePackageListWrapper: React.FunctionComponent<VulnerablePac
           vulnerablePackages={unfilteredVulnerableReleasesFromTree}
           quickView={quickViewConfig}
           setIgnoreFindings={toggleIgnoreFindings}
+          setShowCompleteAnalysis={setShowCompleteAnalysis}
           severity={severity}
           setSeverity={setSeverity}
           shouldIgnore={shouldIgnore}

--- a/lunatrace/bsl/frontend/src/pages/project/builds/details/vulnerable-packages/VulnerablePackagesList.tsx
+++ b/lunatrace/bsl/frontend/src/pages/project/builds/details/vulnerable-packages/VulnerablePackagesList.tsx
@@ -13,7 +13,7 @@
  */
 import { SeverityNamesOsv, severityOrderOsv } from '@lunatrace/lunatrace-common/build/main';
 import React, { ChangeEvent } from 'react';
-import { Button, Col, Dropdown, OverlayTrigger, Row } from 'react-bootstrap';
+import { Button, Col, Dropdown, Form, OverlayTrigger, Row } from 'react-bootstrap';
 import { FcPlus } from 'react-icons/fc';
 
 import { isDirectDep } from '../../../../../utils/package';
@@ -26,6 +26,7 @@ import { VulnerablePackageMain } from './vulnerable-package-card/VulnerablePacka
 interface FindingListProps {
   quickView: QuickViewProps;
   setIgnoreFindings: (ignored: boolean) => void;
+  setShowCompleteAnalysis: (complete: boolean) => void;
   vulnerablePackages: VulnerablePackage[];
   severity: SeverityNamesOsv;
   setSeverity: (s: SeverityNamesOsv) => void;
@@ -35,6 +36,7 @@ interface FindingListProps {
 export const VulnerablePackagesList: React.FunctionComponent<FindingListProps> = ({
   quickView,
   setIgnoreFindings,
+  setShowCompleteAnalysis,
   vulnerablePackages,
   severity,
   setSeverity,
@@ -51,6 +53,7 @@ export const VulnerablePackagesList: React.FunctionComponent<FindingListProps> =
   const packagesFilteredBySeverity = vulnerablePackages.filter((p) => !p.beneath_minimum_severity);
 
   const handleShowIgnoredFindings = (e: ChangeEvent<HTMLInputElement>) => setIgnoreFindings(!e.target.checked);
+  const handleShowCompleteAnalysis = (e: ChangeEvent<HTMLInputElement>) => setShowCompleteAnalysis(e.target.checked);
 
   const pkgCards = packagesFilteredBySeverity.map((p) => {
     return (
@@ -91,33 +94,33 @@ export const VulnerablePackagesList: React.FunctionComponent<FindingListProps> =
           </Row>
         </Col>
         <Col lg="6" style={{ display: 'flex', justifyContent: 'right' }}>
-          <label className="form-check mx-2 p-1 cursor-pointer user-select-none">
-            <input className="form-check-input" type="checkbox" value="" onChange={handleShowIgnoredFindings} />
-            Show Ignored
-          </label>
-          <Dropdown align={{ md: 'end' }} className="d-inline me-2">
-            <Dropdown.Toggle variant="secondary" className="text-capitalize">
-              Minimum Severity: {severity === 'Unknown' ? 'None' : severity}
-            </Dropdown.Toggle>
-            <Dropdown.Menu>
-              <Dropdown.Header>
-                Lowest severity to show <hr className="m-1" />
-              </Dropdown.Header>
-              {severityOrderOsv
-                .map((severityName) => {
-                  return (
-                    <Dropdown.Item
-                      active={severityName === severity}
-                      onClick={() => setSeverity(severityName as SeverityNamesOsv)}
-                      key={severityName}
-                    >
-                      {severityName === 'Unknown' ? 'None' : severityName}
-                    </Dropdown.Item>
-                  );
-                })
-                .reverse()}
-            </Dropdown.Menu>
-          </Dropdown>
+          <Form>
+            <Form.Check type={'checkbox'} label={'Show Ignored'} onChange={handleShowIgnoredFindings} />
+            <Form.Check type={'checkbox'} label={'Show Complete Analysis'} onChange={handleShowCompleteAnalysis} />
+            <Dropdown align={{ md: 'end' }} className="d-inline me-2">
+              <Dropdown.Toggle variant="secondary" className="text-capitalize">
+                Minimum Severity: {severity === 'Unknown' ? 'None' : severity}
+              </Dropdown.Toggle>
+              <Dropdown.Menu>
+                <Dropdown.Header>
+                  Lowest severity to show <hr className="m-1" />
+                </Dropdown.Header>
+                {severityOrderOsv
+                  .map((severityName) => {
+                    return (
+                      <Dropdown.Item
+                        active={severityName === severity}
+                        onClick={() => setSeverity(severityName as SeverityNamesOsv)}
+                        key={severityName}
+                      >
+                        {severityName === 'Unknown' ? 'None' : severityName}
+                      </Dropdown.Item>
+                    );
+                  })
+                  .reverse()}
+              </Dropdown.Menu>
+            </Dropdown>
+          </Form>
         </Col>
       </Row>
       <br />

--- a/lunatrace/bsl/frontend/src/pages/project/builds/details/vulnerable-packages/types.ts
+++ b/lunatrace/bsl/frontend/src/pages/project/builds/details/vulnerable-packages/types.ts
@@ -18,6 +18,10 @@ export type VulnerablePackage = NonNullable<
   NonNullable<GetVulnerableReleasesFromBuildQuery>['vulnerableReleasesFromBuild']
 >[number];
 
+export type Chain = NonNullable<
+  NonNullable<GetVulnerableReleasesFromBuildQuery>['vulnerableReleasesFromBuild']
+>[number]['chains'][number];
+
 export type Guide = VulnerablePackage['guides'][number];
 
 export type VulnMeta = VulnerablePackage['affected_by'][number];

--- a/lunatrace/bsl/frontend/src/pages/project/builds/details/vulnerable-packages/vulnerable-package-card/DepChains.tsx
+++ b/lunatrace/bsl/frontend/src/pages/project/builds/details/vulnerable-packages/vulnerable-package-card/DepChains.tsx
@@ -19,7 +19,7 @@ import { CheckCircle, Maximize2, Minimize2 } from 'react-feather';
 import 'react-perfect-scrollbar/dist/css/styles.css';
 import { Analysis_Finding_Type_Enum } from '../../../../../../api/generated';
 import { LinkInNewTab } from '../../../../../../components/utils/LinkInNewTab';
-import { VulnerablePackage } from '../types';
+import { Chain, VulnerablePackage } from '../types';
 
 import { ChainDep } from './ChainDep';
 interface TreeInfoProps {
@@ -39,6 +39,13 @@ export const DepChains: React.FunctionComponent<TreeInfoProps> = ({ pkg }) => {
   // when chains are collapsed they can end up as dupes, so we use this to hide the dupes
   const chainDedupeSlugs: string[] = [];
 
+  const getVisibleChain = (chain: Chain) => {
+    if (isExpanded || chain.length === 0) {
+      return chain;
+    }
+    return [chain[0], chain[chain.length - 1]];
+  };
+
   // Todo: most of the data processing logic for the chains happens IN the render. It's pretty terse, so it could happen before in a separate step
   // Also too many inline styles. Overall this needs a rewrite someday, in the mean time contact Forrest if it breaks
   return (
@@ -49,9 +56,9 @@ export const DepChains: React.FunctionComponent<TreeInfoProps> = ({ pkg }) => {
             Direct Dependency: <span className="lighter">{chains[0][0].range}</span>
           </>
         ) : (
-          'Transitive Dependency'
+          'Transitive Dependency Analysis'
         )}
-        {!isDirectDep && (
+        {!isDirectDep && chains.length > 0 && (
           <NavLink onClick={() => setIsExpanded(!isExpanded)} style={{ display: 'inline' }}>
             {isExpanded ? <Minimize2 size="1rem" /> : <Maximize2 size="1rem" />}
           </NavLink>
@@ -59,7 +66,7 @@ export const DepChains: React.FunctionComponent<TreeInfoProps> = ({ pkg }) => {
       </h5>
       {!isDirectDep &&
         chains.map((chain) => {
-          const visibleChain = isExpanded ? chain : [chain[0], chain[chain.length - 1]];
+          const visibleChain = getVisibleChain(chain);
           const dedupeSlug = visibleChain.reduce((slug, chain) => slug + chain.release.package.name, '');
           if (chainDedupeSlugs.includes(dedupeSlug)) {
             return null;

--- a/lunatrace/bsl/frontend/src/pages/project/builds/details/vulnerable-packages/vulnerable-package-card/PackageCardBody.tsx
+++ b/lunatrace/bsl/frontend/src/pages/project/builds/details/vulnerable-packages/vulnerable-package-card/PackageCardBody.tsx
@@ -54,7 +54,7 @@ export const PackageCardBody: React.FunctionComponent<VulnerablePackageCardBodyP
         </Container>
       </ConditionallyRender>
 
-      <div className="m-lg-4">
+      <div className="m-lg-2">
         <PackageDetails pkg={pkg} />
         <Row>
           <Accordion defaultActiveKey={findings.length > 2 ? 'nonexistant' : '0'}>

--- a/lunatrace/bsl/frontend/src/pages/project/builds/details/vulnerable-packages/vulnerable-package-card/PackageDetails.tsx
+++ b/lunatrace/bsl/frontend/src/pages/project/builds/details/vulnerable-packages/vulnerable-package-card/PackageDetails.tsx
@@ -26,28 +26,18 @@ interface PackageDetailsProps {
 }
 
 export const PackageDetails: React.FunctionComponent<PackageDetailsProps> = ({ pkg }) => {
-  const recommendedVersion = semver.rsort([...pkg.fix_versions])[0];
-
   return (
     <div className="mb-3">
-      {recommendedVersion && (
-        <Row>
-          <h5>
-            <span className="darker">Recommended version: </span>
-            {recommendedVersion}
-          </h5>
-        </Row>
-      )}
-      <Row>
-        <Col xl={6} lg={12}>
+      <Row className={'d-flex flex-row'}>
+        <Col xl={6} lg={12} className={'flex-grow-1'}>
           <h5>
             <span className="darker">{pluralizeIfMultiple(pkg.paths.length, 'Path') + ': '}</span>
             {pkg.paths.map((path, index) => {
               return (
-                <>
+                <div key={index}>
                   {index > 0 && <br />}
                   <span className="lighter mx-1">{path}</span>
-                </>
+                </div>
               );
             })}
           </h5>

--- a/lunatrace/bsl/frontend/src/pages/project/builds/details/vulnerable-packages/vulnerable-package-card/PackageUpdatablePopOver.tsx
+++ b/lunatrace/bsl/frontend/src/pages/project/builds/details/vulnerable-packages/vulnerable-package-card/PackageUpdatablePopOver.tsx
@@ -72,7 +72,7 @@ export const PackageUpdatablePopOver: React.FC<{ pkg: VulnerablePackage }> = ({ 
   const mdOrLarger = useBreakpoint('md');
   return (
     <>
-      {', '}
+      {' '}
       <OverlayTrigger trigger="click" rootClose placement={mdOrLarger ? 'right' : 'bottom'} overlay={renderToolTip}>
         <NavLink className="primary-color d-inline m-0 p-0">
           {trivialUpdateStatus === 'partially' ? 'partially ' : ''}updatable

--- a/lunatrace/bsl/frontend/src/pages/project/builds/details/vulnerable-packages/vulnerable-package-card/VulnerablePackageCardHeader.tsx
+++ b/lunatrace/bsl/frontend/src/pages/project/builds/details/vulnerable-packages/vulnerable-package-card/VulnerablePackageCardHeader.tsx
@@ -15,6 +15,7 @@ import React from 'react';
 import { Card, Col, NavLink, OverlayTrigger, Popover, Row, Tooltip } from 'react-bootstrap';
 import { CopyBlock, tomorrowNight } from 'react-code-blocks';
 import { Upload } from 'react-feather';
+import semver from 'semver';
 
 import { PackageManagerLink } from '../../../../../../components/PackageManagerLink';
 import useBreakpoint from '../../../../../../hooks/useBreakpoint';
@@ -31,17 +32,24 @@ export const VulnerablePackageCardHeader: React.FunctionComponent<VulnerablePack
   pkg,
   ignored,
 }) => {
+  const recommendedVersion = semver.rsort([...pkg.fix_versions])[0];
   return (
     <Card.Header>
-      <div className="ms-lg-4 me-lg-4">
+      <div className="ms-lg-2 me-lg-2">
         <Row>
           <Col sm="6">
             <Card.Title>
               <h2 className={ignored ? 'text-decoration-line-through' : ''}>{pkg.release.package.name}</h2>
             </Card.Title>
             <Card.Subtitle>
-              <span className="darker">Version: </span>
+              <span className="darker">Installed: </span>
               {pkg.release.version}
+              {recommendedVersion && (
+                <>
+                  <span className="darker">, Recommended: </span>
+                  {recommendedVersion}
+                </>
+              )}
               <PackageUpdatablePopOver pkg={pkg} />
               <PackageManagerLink
                 packageName={pkg.release.package.name}

--- a/lunatrace/bsl/frontend/src/pages/project/builds/details/vulnerable-packages/vulnerable-package-card/findings/VulnInfoTableRow.tsx
+++ b/lunatrace/bsl/frontend/src/pages/project/builds/details/vulnerable-packages/vulnerable-package-card/findings/VulnInfoTableRow.tsx
@@ -108,7 +108,7 @@ export const VulnInfoTableRow: React.FC<VulnerabilityTableItemProps> = ({ vulnMe
           key={c.id}
           id={c.cwe.id}
           name={c.cwe.name}
-          common_name={c.cwe.common_name}
+          common_name={c.cwe.common_name || undefined}
           quickView={quickView}
           tooltipDescription={true}
         />

--- a/lunatrace/bsl/ingest-worker/pkg/staticanalysis/dependencyedge.go
+++ b/lunatrace/bsl/ingest-worker/pkg/staticanalysis/dependencyedge.go
@@ -54,6 +54,10 @@ func validateGetManifestDependencyEdgeResponse(logger zerolog.Logger, resp *gql.
 }
 
 func getManifestDependencyEdgeLocations(output *rules.SemgrepRuleOutput) *gql.Analysis_manifest_dependency_edge_result_location_arr_rel_insert_input {
+	if len(output.Results) == 0 {
+		return nil
+	}
+
 	var locations []*gql.Analysis_manifest_dependency_edge_result_location_insert_input
 	for _, result := range output.Results {
 		locations = append(locations, &gql.Analysis_manifest_dependency_edge_result_location_insert_input{


### PR DESCRIPTION
There are a lot of dependency chains that get returned to the project page for normal sized projects when there are a number of vulnerabilities. These changes improve the performance of loading pages by ~50%.