### PR TITLE
Builds create releases

### DIFF
--- a/lunatrace/bsl/backend/src/database/dependency-relationship-dag-calculator.ts
+++ b/lunatrace/bsl/backend/src/database/dependency-relationship-dag-calculator.ts
@@ -20,6 +20,7 @@ import { DepTreeDep } from 'snyk-nodejs-lockfile-parser-lunatrace-fork/dist/pars
 export interface DependencyGraphNode {
   treeHashId: string;
   packageData: DepTreeDep;
+  mirroredBlobUrl?: string;
   packageEcosystem: string;
   customRegistry: string;
   parentRange?: string;

--- a/lunatrace/bsl/backend/src/manual-scripts/insert-tree.ts
+++ b/lunatrace/bsl/backend/src/manual-scripts/insert-tree.ts
@@ -21,4 +21,9 @@ import { snapshotPinnedDependencies } from '../snapshot/node-package-tree';
 const fixturePath = path.resolve(os.homedir(), 'tmp/beer-me');
 console.log('loading from ', fixturePath);
 // again change the buildId to whatever you want
-void snapshotPinnedDependencies('736de7fc-2df3-4438-af90-b3596f65dd8d', fixturePath);
+void snapshotPinnedDependencies(
+  '736de7fc-2df3-4438-af90-b3596f65dd8d',
+  fixturePath,
+  undefined,
+  '999fe4f2-9f6c-4e11-9b00-56fe2092ad2c'
+);

--- a/lunatrace/bsl/backend/src/manual-scripts/insert-tree.ts
+++ b/lunatrace/bsl/backend/src/manual-scripts/insert-tree.ts
@@ -24,6 +24,6 @@ console.log('loading from ', fixturePath);
 void snapshotPinnedDependencies(
   '736de7fc-2df3-4438-af90-b3596f65dd8d',
   fixturePath,
-  undefined,
+  'http://some.code.url',
   '999fe4f2-9f6c-4e11-9b00-56fe2092ad2c'
 );

--- a/lunatrace/bsl/backend/src/snapshot/node-package-tree.ts
+++ b/lunatrace/bsl/backend/src/snapshot/node-package-tree.ts
@@ -231,7 +231,7 @@ async function insertNodesToDatabase<Ext>(
         packageData.name || '',
         packageData.packageManager,
         // top nodes should use a custom namespace per org.
-        isTopLevel ? 'lunatrace-internal-project-' + projectId : packageData.customRegistry,
+        isTopLevel ? `lunatrace-internal-project-${projectId}` : packageData.customRegistry,
         // top nodes don't have a parent and are internal.
         !isTopLevel
       );
@@ -239,7 +239,7 @@ async function insertNodesToDatabase<Ext>(
       const packageReleaseId = await getPackageReleaseId(
         t,
         packageId,
-        isTopLevel ? `${packageData?.version}-${buildId}` : packageData.version || '',
+        isTopLevel ? `${packageData?.version}-${buildId}-unique` : packageData.version || '',
         node.mirroredBlobUrl
       );
 

--- a/lunatrace/bsl/backend/src/snapshot/node-package-tree.ts
+++ b/lunatrace/bsl/backend/src/snapshot/node-package-tree.ts
@@ -109,14 +109,14 @@ export async function collectPackageGraphsFromDirectory(repoDir: string): Promis
       // This value is set to false by the library when there are zero dev dependencies
       const prodOrDevLabel = pkgTree.hasDevDependencies ? 'dev' : 'prod';
 
-      const pkgDependenciesWithGraphAndMetadata = [...Object.values(pkgTree.dependencies), pkgTree].map((pkg) => {
+      const pkgDependenciesWithGraphAndMetadata = [pkgTree, ...Object.values(pkgTree.dependencies)].map((pkg) => {
         return {
           node: dfsGenerateMerkleTreeFromDepTree(pkg),
           // If there is nothing in the labels, then we know that it is a prod dependency
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           labels: pkg.labels ?? ({ scope: prodOrDevLabel } as any),
           name: pkg.name,
-          range: pkg.range,
+          range: pkg.range || pkg.version,
           version: pkg.version,
         };
       });

--- a/lunatrace/bsl/backend/src/snapshot/node-package-tree.ts
+++ b/lunatrace/bsl/backend/src/snapshot/node-package-tree.ts
@@ -443,11 +443,11 @@ export async function insertPackageManifestsIntoDatabase(
     await Promise.all(
       pkgGraphs.map(async (pkgGraph) => {
         const manifestId = await trsx.one<{ id: string }>(
-          `INSERT INTO resolved_manifest (build_id, path, package_manager, lockfile_version)
-           VALUES ($1, $2, $3, $4)
+          `INSERT INTO resolved_manifest (build_id, path, package_manager, lockfile_version, manifest_dependency_node_id)
+           VALUES ($1, $2, $3, $4, $5)
            ON CONFLICT DO NOTHING
            RETURNING id`,
-          [buildId, pkgGraph.lockFilePath, pkgGraph.packageManager, pkgGraph.lockfileVersion]
+          [buildId, pkgGraph.lockFilePath, pkgGraph.packageManager, pkgGraph.lockfileVersion, pkgGraph.rootTreeHashID]
         );
 
         log.info(`Inserted manifest for build`, {

--- a/lunatrace/bsl/backend/src/snapshot/node-package-tree.ts
+++ b/lunatrace/bsl/backend/src/snapshot/node-package-tree.ts
@@ -203,7 +203,8 @@ async function getPackageReleaseId<Ext>(t: ITask<Ext>, packageId: string, versio
 async function insertNodesToDatabase<Ext>(
   t: ITask<Ext>,
   queryData: DependencyGraphNode[],
-  projectId: string
+  projectId: string,
+  buildId: string
 ): Promise<void> {
   if (queryData.length === 0) {
     return;
@@ -235,7 +236,12 @@ async function insertNodesToDatabase<Ext>(
         !isTopLevel
       );
 
-      const packageReleaseId = await getPackageReleaseId(t, packageId, packageData.version || '', node.mirroredBlobUrl);
+      const packageReleaseId = await getPackageReleaseId(
+        t,
+        packageId,
+        isTopLevel ? `${packageData?.version}-${buildId}` : packageData.version || '',
+        node.mirroredBlobUrl
+      );
 
       return {
         id: node.treeHashId,
@@ -414,7 +420,7 @@ async function insertPackageGraphsIntoDatabase(
       for (let i = 0; i < dependencyNodeMap.size; i += 999) {
         const dependencySlice = sortedDependencyNodes.slice(i, i + 999);
 
-        await insertNodesToDatabase(t, dependencySlice, projectId);
+        await insertNodesToDatabase(t, dependencySlice, projectId, buildId);
 
         log.info(`Inserted nodes (${i + dependencySlice.length}/${dependencyNodeMap.size})`, {
           length: dependencySlice.length,

--- a/lunatrace/bsl/backend/src/snapshot/node-package-tree.ts
+++ b/lunatrace/bsl/backend/src/snapshot/node-package-tree.ts
@@ -390,10 +390,6 @@ async function insertPackageGraphsIntoDatabase(projectId: string, pkgGraphs: Col
   // We're mutating state which is where bugs stem from.
   // This will reduce memory usage though, so we'll allow it.
   for (const id of currentlyKnownTransitiveDependencyIds) {
-    // always insert root nodes even if they're known
-    if (!dependencyNodeMap?.get(id)?.parent) {
-      continue;
-    }
     dependencyNodeMap.delete(id);
   }
 

--- a/lunatrace/bsl/backend/src/snapshot/node-package-tree.ts
+++ b/lunatrace/bsl/backend/src/snapshot/node-package-tree.ts
@@ -14,7 +14,7 @@
 import path from 'path';
 
 import { ITask } from 'pg-promise';
-import { buildDepTreeFromFiles } from 'snyk-nodejs-lockfile-parser-lunatrace-fork';
+import { buildDepTreeFromFiles, PkgTree } from 'snyk-nodejs-lockfile-parser-lunatrace-fork';
 
 import { db, pgp } from '../database/db';
 import {
@@ -108,7 +108,7 @@ export async function collectPackageGraphsFromDirectory(repoDir: string): Promis
       // This value is set to false by the library when there are zero dev dependencies
       const prodOrDevLabel = pkgTree.hasDevDependencies ? 'dev' : 'prod';
 
-      const pkgDependenciesWithGraphAndMetadata = Object.values(pkgTree.dependencies).map((pkg) => {
+      const pkgDependenciesWithGraphAndMetadata = [...Object.values(pkgTree.dependencies), pkgTree].map((pkg) => {
         return {
           rootNode: dfsGenerateMerkleTreeFromDepTree(pkg),
           // If there is nothing in the labels, then we know that it is a prod dependency
@@ -477,7 +477,7 @@ export async function insertPackageManifestsIntoDatabase(
   });
 }
 
-export async function snapshotPinnedDependencies(buildId: string, repoDir: string): Promise<void> {
+export async function snapshotPinnedDependencies(buildId: string, repoDir: string, codeUrl: string): Promise<void> {
   const pkgTree = await collectPackageGraphsFromDirectory(repoDir);
 
   // Creates all nodes and edges for the dependency graph into the database

--- a/lunatrace/bsl/backend/src/snapshot/node-package-tree.ts
+++ b/lunatrace/bsl/backend/src/snapshot/node-package-tree.ts
@@ -117,7 +117,8 @@ export async function collectPackageGraphsFromDirectory(
         pkgTree.version = `${pkgTree.version}-${rootUniqueId}`;
       }
 
-      const pkgDependenciesWithGraphAndMetadata = [pkgTree, ...Object.values(pkgTree.dependencies)].map((pkg) => {
+      const flatDeps = [pkgTree, ...Object.values(pkgTree.dependencies)];
+      const pkgDependenciesWithGraphAndMetadata = flatDeps.map((pkg) => {
         return {
           node: dfsGenerateMerkleTreeFromDepTree(pkg),
           // If there is nothing in the labels, then we know that it is a prod dependency

--- a/lunatrace/bsl/backend/src/tests/node-package-tree-insertion-integration-DEPRECATED.test.ts
+++ b/lunatrace/bsl/backend/src/tests/node-package-tree-insertion-integration-DEPRECATED.test.ts
@@ -100,7 +100,7 @@ function testAllTreeTypes() {
         backup?.restore();
         await pgPromiseDb.none(`INSERT INTO builds (id, source_type) VALUES ($1, 'pr')`, [buildIdOne]);
 
-        await snapshotPinnedDependencies(buildIdOne, fixturePath);
+        await snapshotPinnedDependencies(buildIdOne, fixturePath, undefined, '999fe4f2-9f6c-4e11-9b00-56fe2092ad2c');
 
         const initialManifests = await db.many<{ id: string; build_id: string; path: string }>(
           `SELECT id, build_id, path FROM manifest`
@@ -118,7 +118,7 @@ function testAllTreeTypes() {
 
         await pgPromiseDb.none(`INSERT INTO builds (id, source_type) VALUES ($1, 'pr')`, [buildIdTwo]);
 
-        await snapshotPinnedDependencies(buildIdTwo, fixturePath);
+        await snapshotPinnedDependencies(buildIdTwo, fixturePath, undefined, '999fe4f2-9f6c-4e11-9b00-56fe2092ad2c');
 
         const bothManifests = await db.many<{ id: string; build_id: string; path: string }>(
           `SELECT id, build_id, path FROM manifest`

--- a/lunatrace/bsl/backend/src/tests/node-package-tree-insertion-integration-DEPRECATED.test.ts
+++ b/lunatrace/bsl/backend/src/tests/node-package-tree-insertion-integration-DEPRECATED.test.ts
@@ -100,7 +100,7 @@ function testAllTreeTypes() {
         backup?.restore();
         await pgPromiseDb.none(`INSERT INTO builds (id, source_type) VALUES ($1, 'pr')`, [buildIdOne]);
 
-        await snapshotPinnedDependencies(buildIdOne, fixturePath, undefined, '999fe4f2-9f6c-4e11-9b00-56fe2092ad2c');
+        await snapshotPinnedDependencies(buildIdOne, fixturePath, '', '999fe4f2-9f6c-4e11-9b00-56fe2092ad2c');
 
         const initialManifests = await db.many<{ id: string; build_id: string; path: string }>(
           `SELECT id, build_id, path FROM manifest`
@@ -118,7 +118,7 @@ function testAllTreeTypes() {
 
         await pgPromiseDb.none(`INSERT INTO builds (id, source_type) VALUES ($1, 'pr')`, [buildIdTwo]);
 
-        await snapshotPinnedDependencies(buildIdTwo, fixturePath, undefined, '999fe4f2-9f6c-4e11-9b00-56fe2092ad2c');
+        await snapshotPinnedDependencies(buildIdTwo, fixturePath, '', '999fe4f2-9f6c-4e11-9b00-56fe2092ad2c');
 
         const bothManifests = await db.many<{ id: string; build_id: string; path: string }>(
           `SELECT id, build_id, path FROM manifest`

--- a/lunatrace/bsl/backend/src/workers/queue/activities/snapshot-repository-activity.ts
+++ b/lunatrace/bsl/backend/src/workers/queue/activities/snapshot-repository-activity.ts
@@ -89,9 +89,9 @@ async function performSnapshotOnRepository(
     });
 
     logger.info('Attempting to upload worktree snapshot for repository.');
-    const codeURL = '';
+    let codeURL = '';
     try {
-      await uploadWorktreeSnapshot(buildId, repoDir);
+      codeURL = await uploadWorktreeSnapshot(buildId, repoDir);
     } catch (err) {
       logger.error(failedToUploadWorktreeSnapshotForRepository, {
         error: err,

--- a/lunatrace/bsl/backend/src/workers/queue/activities/snapshot-repository-activity.ts
+++ b/lunatrace/bsl/backend/src/workers/queue/activities/snapshot-repository-activity.ts
@@ -87,31 +87,8 @@ async function performSnapshotOnRepository(
       s3Url: s3UploadRes,
     });
 
-    logger.info('Attempting to snapshot pinned dependencies for repository.');
-
-    const pkgTrees = null;
-    try {
-      await snapshotPinnedDependencies(buildId, repoDir);
-    } catch (err) {
-      logger.error('Failed to snapshot pinned dependencies for repository.', {
-        error: err,
-      });
-      updateBuildStatus(
-        buildId,
-        Build_State_Enum.SnapshotFailed,
-        'Failed to snapshot pinned dependencies for repository.'
-      );
-
-      return {
-        error: true,
-        msg: 'failed to snapshot pinned dependencies',
-        rawError: err instanceof Error ? err : undefined,
-      };
-    }
-
-    logger.info('Successfully created snapshot for pinned dependencies for repository.');
-
     logger.info('Attempting to upload worktree snapshot for repository.');
+    const codeURL = '';
     try {
       await uploadWorktreeSnapshot(buildId, repoDir);
     } catch (err) {
@@ -130,7 +107,29 @@ async function performSnapshotOnRepository(
 
     logger.info('Successfully created snapshots for repository.');
 
-    // create shadow releases using gql
+    // create releases with uploaded tar url.
+    logger.info('Attempting to snapshot pinned dependencies for repository.');
+
+    try {
+      await snapshotPinnedDependencies(buildId, repoDir, codeURL);
+    } catch (err) {
+      logger.error('Failed to snapshot pinned dependencies for repository.', {
+        error: err,
+      });
+      updateBuildStatus(
+        buildId,
+        Build_State_Enum.SnapshotFailed,
+        'Failed to snapshot pinned dependencies for repository.'
+      );
+
+      return {
+        error: true,
+        msg: 'failed to snapshot pinned dependencies',
+        rawError: err instanceof Error ? err : undefined,
+      };
+    }
+
+    logger.info('Successfully created snapshot for pinned dependencies for repository.');
 
     updateBuildStatus(buildId, Build_State_Enum.SnapshotCompleted);
 

--- a/lunatrace/bsl/backend/src/workers/queue/activities/snapshot-repository-activity.ts
+++ b/lunatrace/bsl/backend/src/workers/queue/activities/snapshot-repository-activity.ts
@@ -43,7 +43,8 @@ async function performSnapshotOnRepository(
   buildId: string,
   cloneUrl: string,
   gitBranch: string,
-  gitCommit?: string
+  gitCommit?: string,
+  projectId?: string
 ): Promise<MaybeErrorVoid> {
   let logger = log.child('snapshot-repository-activity');
   logger.info('Starting to snapshot repository.');
@@ -111,7 +112,7 @@ async function performSnapshotOnRepository(
     logger.info('Attempting to snapshot pinned dependencies for repository.');
 
     try {
-      await snapshotPinnedDependencies(buildId, repoDir, codeURL);
+      await snapshotPinnedDependencies(buildId, repoDir, codeURL, projectId);
     } catch (err) {
       logger.error('Failed to snapshot pinned dependencies for repository.', {
         error: err,
@@ -200,7 +201,14 @@ export async function snapshotRepositoryActivity(req: SnapshotForRepositoryReque
   const installationId = req.installationId.toString();
 
   return await log.provideFields({ buildId: req.buildId, record: req, installationId }, async () => {
-    return performSnapshotOnRepository(installationId, req.buildId, repoClone.cloneUrl, req.gitBranch, req.gitCommit);
+    return performSnapshotOnRepository(
+      installationId,
+      req.buildId,
+      repoClone.cloneUrl,
+      req.gitBranch,
+      req.gitCommit,
+      req.projectId
+    );
   });
 }
 

--- a/lunatrace/bsl/hasura/metadata/remote_schemas.yaml
+++ b/lunatrace/bsl/hasura/metadata/remote_schemas.yaml
@@ -13,11 +13,10 @@
     - role: user
       definition:
         schema: |
-          scalar JSON
-          scalar UUID
           type AuthenticatedRepoCloneUrlOutput {
             url: String
           }
+          scalar JSON
           type Mutation {
             presignManifestUpload(project_id: UUID!): PresignedUrlResponse
           }
@@ -36,6 +35,7 @@
             error: Boolean!
             uploadUrl: UploadUrl
           }
+          scalar UUID
           type UploadUrl {
             headers: JSON!
             url: String!
@@ -43,11 +43,10 @@
     - role: service
       definition:
         schema: |
-          scalar JSON
-          scalar UUID
           type AuthenticatedRepoCloneUrlOutput {
             url: String
           }
+          scalar JSON
           type Mutation {
             presignManifestUpload(project_id: UUID!): PresignedUrlResponse
           }
@@ -63,23 +62,23 @@
             presignSbomUpload(orgId: UUID!, buildId: UUID!): SbomUploadUrlOutput
             sbomUrl(buildId: UUID!): String
           }
+          input SbomUploadUrlInput {
+            orgId: UUID!
+            projectId: UUID!
+          }
           type SbomUploadUrlOutput {
             error: Boolean!
             uploadUrl: UploadUrl
           }
+          scalar UUID
           type UploadUrl {
             headers: JSON!
             url: String!
-          }
-          input SbomUploadUrlInput {
-            orgId: UUID!
-            projectId: UUID!
           }
     - role: cli
       definition:
         schema: |
           scalar JSON
-          scalar UUID
           type Query {
             presignSbomUpload(orgId: UUID!, buildId: UUID!): SbomUploadUrlOutput
           }
@@ -87,6 +86,7 @@
             error: Boolean!
             uploadUrl: UploadUrl
           }
+          scalar UUID
           type UploadUrl {
             headers: JSON!
             url: String!

--- a/lunatrace/bsl/hasura/migrations/lunatrace/1670273332443_alter_table_public_manifest_dependency_node_alter_column_range/down.sql
+++ b/lunatrace/bsl/hasura/migrations/lunatrace/1670273332443_alter_table_public_manifest_dependency_node_alter_column_range/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.manifest_dependency_node
+    ALTER COLUMN range SET NOT NULL;

--- a/lunatrace/bsl/hasura/migrations/lunatrace/1670273332443_alter_table_public_manifest_dependency_node_alter_column_range/up.sql
+++ b/lunatrace/bsl/hasura/migrations/lunatrace/1670273332443_alter_table_public_manifest_dependency_node_alter_column_range/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.manifest_dependency_node
+    ALTER COLUMN range DROP NOT NULL;

--- a/lunatrace/gogen/gql/gen.go
+++ b/lunatrace/gogen/gql/gen.go
@@ -379,7 +379,7 @@ func (v *Analysis_manifest_dependency_edge_result_location_bool_exp) GetStart_ro
 type Analysis_manifest_dependency_edge_result_location_constraint string
 
 const (
-	Analysis_manifest_dependency_edge_result_location_constraintManifestDependencyEdgeResultCallsitePkey Analysis_manifest_dependency_edge_result_location_constraint = "manifest_dependency_edge_result_callsite_pkey"
+	Analysis_manifest_dependency_edge_result_location_constraintManifestDependencyEdgeResultLocationPkey Analysis_manifest_dependency_edge_result_location_constraint = "manifest_dependency_edge_result_location_pkey"
 )
 
 type Analysis_manifest_dependency_edge_result_location_insert_input struct {
@@ -1818,6 +1818,7 @@ func (v *GetManifestDependencyEdgeManifest_dependency_edge_by_pkManifest_depende
 // GetManifestDependencyEdgeManifest_dependency_edge_by_pkManifest_dependency_edgeParentManifest_dependency_nodeReleasePackage_release includes the requested fields of the GraphQL type package_release.
 type GetManifestDependencyEdgeManifest_dependency_edge_by_pkManifest_dependency_edgeParentManifest_dependency_nodeReleasePackage_release struct {
 	Upstream_blob_url *string                                                                                                                                     `json:"upstream_blob_url"`
+	Mirrored_blob_url *string                                                                                                                                     `json:"mirrored_blob_url"`
 	Version           string                                                                                                                                      `json:"version"`
 	Package           *GetManifestDependencyEdgeManifest_dependency_edge_by_pkManifest_dependency_edgeParentManifest_dependency_nodeReleasePackage_releasePackage `json:"package"`
 }
@@ -1825,6 +1826,11 @@ type GetManifestDependencyEdgeManifest_dependency_edge_by_pkManifest_dependency_
 // GetUpstream_blob_url returns GetManifestDependencyEdgeManifest_dependency_edge_by_pkManifest_dependency_edgeParentManifest_dependency_nodeReleasePackage_release.Upstream_blob_url, and is useful for accessing the field via an interface.
 func (v *GetManifestDependencyEdgeManifest_dependency_edge_by_pkManifest_dependency_edgeParentManifest_dependency_nodeReleasePackage_release) GetUpstream_blob_url() *string {
 	return v.Upstream_blob_url
+}
+
+// GetMirrored_blob_url returns GetManifestDependencyEdgeManifest_dependency_edge_by_pkManifest_dependency_edgeParentManifest_dependency_nodeReleasePackage_release.Mirrored_blob_url, and is useful for accessing the field via an interface.
+func (v *GetManifestDependencyEdgeManifest_dependency_edge_by_pkManifest_dependency_edgeParentManifest_dependency_nodeReleasePackage_release) GetMirrored_blob_url() *string {
+	return v.Mirrored_blob_url
 }
 
 // GetVersion returns GetManifestDependencyEdgeManifest_dependency_edge_by_pkManifest_dependency_edgeParentManifest_dependency_nodeReleasePackage_release.Version, and is useful for accessing the field via an interface.
@@ -7902,7 +7908,8 @@ func (v *Vulnerability_vulnerability_cwe_bool_exp) GetVulnerability_id() *Uuid_c
 type Vulnerability_vulnerability_cwe_constraint string
 
 const (
-	Vulnerability_vulnerability_cwe_constraintVulnerabilityCwePkey Vulnerability_vulnerability_cwe_constraint = "vulnerability_cwe_pkey"
+	Vulnerability_vulnerability_cwe_constraintVulnerabilityCwePkey                    Vulnerability_vulnerability_cwe_constraint = "vulnerability_cwe_pkey"
+	Vulnerability_vulnerability_cwe_constraintVulnerabilityCweVulnerabilityIdCweIdKey Vulnerability_vulnerability_cwe_constraint = "vulnerability_cwe_vulnerability_id_cwe_id_key"
 )
 
 type Vulnerability_vulnerability_cwe_insert_input struct {
@@ -8159,6 +8166,7 @@ query GetManifestDependencyEdge ($id: uuid!) {
 		parent {
 			release {
 				upstream_blob_url
+				mirrored_blob_url
 				version
 				package {
 					name

--- a/lunatrace/gogen/gql/graphql/getManifestDependencyEdge.graphql
+++ b/lunatrace/gogen/gql/graphql/getManifestDependencyEdge.graphql
@@ -10,6 +10,7 @@ query GetManifestDependencyEdge($id: uuid!) {
     parent {
       release {
         upstream_blob_url
+        mirrored_blob_url
         version
         package {
           name

--- a/lunatrace/gogen/schema.graphql
+++ b/lunatrace/gogen/schema.graphql
@@ -411,7 +411,7 @@ input analysis_manifest_dependency_edge_result_location_bool_exp {
 }
 
 enum analysis_manifest_dependency_edge_result_location_constraint {
-    manifest_dependency_edge_result_callsite_pkey
+    manifest_dependency_edge_result_location_pkey
 }
 
 input analysis_manifest_dependency_edge_result_location_inc_input {
@@ -2819,7 +2819,7 @@ type manifest_dependency_node {
     id: uuid!
     labels(path: String): jsonb
     parent_edges(distinct_on: [manifest_dependency_edge_select_column!], limit: Int, offset: Int, order_by: [manifest_dependency_edge_order_by!], where: manifest_dependency_edge_bool_exp): [manifest_dependency_edge!]!
-    range: String!
+    range: String
     release: package_release!
     release_id: uuid!
 }
@@ -6718,6 +6718,7 @@ input vulnerability_vulnerability_cwe_bool_exp {
 
 enum vulnerability_vulnerability_cwe_constraint {
     vulnerability_cwe_pkey
+    vulnerability_cwe_vulnerability_id_cwe_id_key
 }
 
 input vulnerability_vulnerability_cwe_inc_input {

--- a/lunatrace/gogen/sqlgen/lunatrace/package/model/release_dependency.go
+++ b/lunatrace/gogen/sqlgen/lunatrace/package/model/release_dependency.go
@@ -15,8 +15,8 @@ type ReleaseDependency struct {
 	ID                  uuid.UUID `sql:"primary_key"`
 	ReleaseID           uuid.UUID
 	DependencyPackageID *uuid.UUID
+	DependencyReleaseID *uuid.UUID
 	PackageName         string
 	PackageVersionQuery string
 	IsDev               bool
-	DependencyReleaseID *uuid.UUID
 }

--- a/lunatrace/gogen/sqlgen/lunatrace/package/table/release_dependency.go
+++ b/lunatrace/gogen/sqlgen/lunatrace/package/table/release_dependency.go
@@ -20,10 +20,10 @@ type releaseDependencyTable struct {
 	ID                  postgres.ColumnString
 	ReleaseID           postgres.ColumnString
 	DependencyPackageID postgres.ColumnString
+	DependencyReleaseID postgres.ColumnString
 	PackageName         postgres.ColumnString
 	PackageVersionQuery postgres.ColumnString
 	IsDev               postgres.ColumnBool
-	DependencyReleaseID postgres.ColumnString
 
 	AllColumns     postgres.ColumnList
 	MutableColumns postgres.ColumnList
@@ -67,12 +67,12 @@ func newReleaseDependencyTableImpl(schemaName, tableName, alias string) releaseD
 		IDColumn                  = postgres.StringColumn("id")
 		ReleaseIDColumn           = postgres.StringColumn("release_id")
 		DependencyPackageIDColumn = postgres.StringColumn("dependency_package_id")
+		DependencyReleaseIDColumn = postgres.StringColumn("dependency_release_id")
 		PackageNameColumn         = postgres.StringColumn("package_name")
 		PackageVersionQueryColumn = postgres.StringColumn("package_version_query")
 		IsDevColumn               = postgres.BoolColumn("is_dev")
-		DependencyReleaseIDColumn = postgres.StringColumn("dependency_release_id")
-		allColumns                = postgres.ColumnList{IDColumn, ReleaseIDColumn, DependencyPackageIDColumn, PackageNameColumn, PackageVersionQueryColumn, IsDevColumn, DependencyReleaseIDColumn}
-		mutableColumns            = postgres.ColumnList{ReleaseIDColumn, DependencyPackageIDColumn, PackageNameColumn, PackageVersionQueryColumn, IsDevColumn, DependencyReleaseIDColumn}
+		allColumns                = postgres.ColumnList{IDColumn, ReleaseIDColumn, DependencyPackageIDColumn, DependencyReleaseIDColumn, PackageNameColumn, PackageVersionQueryColumn, IsDevColumn}
+		mutableColumns            = postgres.ColumnList{ReleaseIDColumn, DependencyPackageIDColumn, DependencyReleaseIDColumn, PackageNameColumn, PackageVersionQueryColumn, IsDevColumn}
 	)
 
 	return releaseDependencyTable{
@@ -82,10 +82,10 @@ func newReleaseDependencyTableImpl(schemaName, tableName, alias string) releaseD
 		ID:                  IDColumn,
 		ReleaseID:           ReleaseIDColumn,
 		DependencyPackageID: DependencyPackageIDColumn,
+		DependencyReleaseID: DependencyReleaseIDColumn,
 		PackageName:         PackageNameColumn,
 		PackageVersionQuery: PackageVersionQueryColumn,
 		IsDev:               IsDevColumn,
-		DependencyReleaseID: DependencyReleaseIDColumn,
 
 		AllColumns:     allColumns,
 		MutableColumns: mutableColumns,


### PR DESCRIPTION
Builds create a root node in the merkle tree that references a release that represents the build.
The package associated with the root node has a unique custom registry based on the project ID and is marked as internal.
A new release is created for each build even if the version number is not changed so we can store the blob url.