### PR TITLE
Add EPSS score migration + indexes for slow queries

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -4,6 +4,7 @@
     <data-source source="LOCAL" name="PostgreSQL - postgres@localhost" uuid="f58754ba-e8ea-4b68-b0ea-dd7be81a5d45">
       <driver-ref>postgresql</driver-ref>
       <synchronize>true</synchronize>
+      <schema-control>AUTOMATIC</schema-control>
       <jdbc-driver>org.postgresql.Driver</jdbc-driver>
       <jdbc-url>jdbc:postgresql://localhost:5431/lunatrace</jdbc-url>
       <working-dir>$ProjectFileDir$</working-dir>

--- a/.idea/dbnavigator.xml
+++ b/.idea/dbnavigator.xml
@@ -48,6 +48,7 @@
     <retain-sticky-names value="false" />
   </component>
   <component name="DBNavigator.Project.FileConnectionMappingManager">
+    <mapping file-url="file://$PROJECT_DIR$/lunatrace/bsl/hasura/migrations/lunatrace/1671051319901_add_epss_score/up.sql" connection-id="2288c982-597b-4cb4-a0b1-d6f80f52304a" session-id="MAIN" current-schema="vulnerability" />
     <mapping file-url="file://$PROJECT_DIR$/lunatrace/bsl/hasura/migrations/lunatrace/1650321911749_add_webhook_cache/up.sql" connection-id="2288c982-597b-4cb4-a0b1-d6f80f52304a" session-id="MAIN" current-schema="public" />
     <mapping file-url="file://$PROJECT_DIR$/lunatrace/bsl/hasura/migrations/lunatrace/1661812840365_manifest_dependency_node_child_edges_recursive/up.sql" connection-id="2288c982-597b-4cb4-a0b1-d6f80f52304a" session-id="MAIN" current-schema="hdb_catalog" />
     <mapping file-url="file://$APPLICATION_CONFIG_DIR$/consoles/db/60703370-4771-453b-81a1-e251ed9b8f3f/console.sql" connection-id="2288c982-597b-4cb4-a0b1-d6f80f52304a" session-id="MAIN" current-schema="hdb_catalog" />
@@ -120,7 +121,7 @@
           <connect-automatically value="true" />
           <restore-workspace value="true" />
           <restore-workspace-deep value="false" />
-          <environment-type value="default" />
+          <environment-type value="development" />
           <connectivity-timeout value="5" />
           <idle-time-to-disconnect value="30" />
           <idle-time-to-disconnect-pool value="5" />
@@ -348,21 +349,21 @@
             <filter-element type="OBJECT" id="dblink" selected="true" />
           </user-schema>
           <public-schema>
-            <filter-element type="OBJECT" id="table" selected="false" />
-            <filter-element type="OBJECT" id="view" selected="false" />
-            <filter-element type="OBJECT" id="materialized view" selected="false" />
-            <filter-element type="OBJECT" id="index" selected="false" />
-            <filter-element type="OBJECT" id="constraint" selected="false" />
-            <filter-element type="OBJECT" id="trigger" selected="false" />
-            <filter-element type="OBJECT" id="synonym" selected="false" />
-            <filter-element type="OBJECT" id="sequence" selected="false" />
-            <filter-element type="OBJECT" id="procedure" selected="false" />
-            <filter-element type="OBJECT" id="function" selected="false" />
-            <filter-element type="OBJECT" id="package" selected="false" />
-            <filter-element type="OBJECT" id="type" selected="false" />
-            <filter-element type="OBJECT" id="dimension" selected="false" />
-            <filter-element type="OBJECT" id="cluster" selected="false" />
-            <filter-element type="OBJECT" id="dblink" selected="false" />
+            <filter-element type="OBJECT" id="table" selected="true" />
+            <filter-element type="OBJECT" id="view" selected="true" />
+            <filter-element type="OBJECT" id="materialized view" selected="true" />
+            <filter-element type="OBJECT" id="index" selected="true" />
+            <filter-element type="OBJECT" id="constraint" selected="true" />
+            <filter-element type="OBJECT" id="trigger" selected="true" />
+            <filter-element type="OBJECT" id="synonym" selected="true" />
+            <filter-element type="OBJECT" id="sequence" selected="true" />
+            <filter-element type="OBJECT" id="procedure" selected="true" />
+            <filter-element type="OBJECT" id="function" selected="true" />
+            <filter-element type="OBJECT" id="package" selected="true" />
+            <filter-element type="OBJECT" id="type" selected="true" />
+            <filter-element type="OBJECT" id="dimension" selected="true" />
+            <filter-element type="OBJECT" id="cluster" selected="true" />
+            <filter-element type="OBJECT" id="dblink" selected="true" />
           </public-schema>
           <any-schema>
             <filter-element type="OBJECT" id="table" selected="true" />

--- a/lunatrace/bsl/backend/src/hasura-api/generated.ts
+++ b/lunatrace/bsl/backend/src/hasura-api/generated.ts
@@ -10302,6 +10302,8 @@ export type Vulnerability = {
   cwes: Array<Vulnerability_Vulnerability_Cwe>;
   database_specific?: Maybe<Scalars['jsonb']>;
   details?: Maybe<Scalars['String']>;
+  epss_percentile?: Maybe<Scalars['Float']>;
+  epss_score?: Maybe<Scalars['Float']>;
   /** An array relationship */
   equivalents: Array<Vulnerability_Equivalent>;
   /** An array relationship */
@@ -11029,6 +11031,8 @@ export type Vulnerability_Bool_Exp = {
   cwes?: InputMaybe<Vulnerability_Vulnerability_Cwe_Bool_Exp>;
   database_specific?: InputMaybe<Jsonb_Comparison_Exp>;
   details?: InputMaybe<String_Comparison_Exp>;
+  epss_percentile?: InputMaybe<Float_Comparison_Exp>;
+  epss_score?: InputMaybe<Float_Comparison_Exp>;
   equivalents?: InputMaybe<Vulnerability_Equivalent_Bool_Exp>;
   findings?: InputMaybe<Findings_Bool_Exp>;
   guide_vulnerabilities?: InputMaybe<Guide_Vulnerabilities_Bool_Exp>;
@@ -11431,6 +11435,8 @@ export enum Vulnerability_Equivalent_Update_Column {
 /** input type for incrementing numeric columns in table "vulnerability.vulnerability" */
 export type Vulnerability_Inc_Input = {
   cvss_score?: InputMaybe<Scalars['Float']>;
+  epss_percentile?: InputMaybe<Scalars['Float']>;
+  epss_score?: InputMaybe<Scalars['Float']>;
 };
 
 /** input type for inserting data into table "vulnerability.vulnerability" */
@@ -11442,6 +11448,8 @@ export type Vulnerability_Insert_Input = {
   cwes?: InputMaybe<Vulnerability_Vulnerability_Cwe_Arr_Rel_Insert_Input>;
   database_specific?: InputMaybe<Scalars['jsonb']>;
   details?: InputMaybe<Scalars['String']>;
+  epss_percentile?: InputMaybe<Scalars['Float']>;
+  epss_score?: InputMaybe<Scalars['Float']>;
   equivalents?: InputMaybe<Vulnerability_Equivalent_Arr_Rel_Insert_Input>;
   findings?: InputMaybe<Findings_Arr_Rel_Insert_Input>;
   guide_vulnerabilities?: InputMaybe<Guide_Vulnerabilities_Arr_Rel_Insert_Input>;
@@ -11492,6 +11500,8 @@ export type Vulnerability_Order_By = {
   cwes_aggregate?: InputMaybe<Vulnerability_Vulnerability_Cwe_Aggregate_Order_By>;
   database_specific?: InputMaybe<Order_By>;
   details?: InputMaybe<Order_By>;
+  epss_percentile?: InputMaybe<Order_By>;
+  epss_score?: InputMaybe<Order_By>;
   equivalents_aggregate?: InputMaybe<Vulnerability_Equivalent_Aggregate_Order_By>;
   findings_aggregate?: InputMaybe<Findings_Aggregate_Order_By>;
   guide_vulnerabilities_aggregate?: InputMaybe<Guide_Vulnerabilities_Aggregate_Order_By>;
@@ -11797,6 +11807,10 @@ export enum Vulnerability_Select_Column {
   /** column name */
   Details = 'details',
   /** column name */
+  EpssPercentile = 'epss_percentile',
+  /** column name */
+  EpssScore = 'epss_score',
+  /** column name */
   Id = 'id',
   /** column name */
   LastFetched = 'last_fetched',
@@ -11826,6 +11840,8 @@ export type Vulnerability_Set_Input = {
   cvss_score?: InputMaybe<Scalars['Float']>;
   database_specific?: InputMaybe<Scalars['jsonb']>;
   details?: InputMaybe<Scalars['String']>;
+  epss_percentile?: InputMaybe<Scalars['Float']>;
+  epss_score?: InputMaybe<Scalars['Float']>;
   id?: InputMaybe<Scalars['uuid']>;
   last_fetched?: InputMaybe<Scalars['timestamptz']>;
   modified?: InputMaybe<Scalars['timestamptz']>;
@@ -11992,6 +12008,10 @@ export enum Vulnerability_Update_Column {
   DatabaseSpecific = 'database_specific',
   /** column name */
   Details = 'details',
+  /** column name */
+  EpssPercentile = 'epss_percentile',
+  /** column name */
+  EpssScore = 'epss_score',
   /** column name */
   Id = 'id',
   /** column name */

--- a/lunatrace/bsl/frontend/src/api/generated.ts
+++ b/lunatrace/bsl/frontend/src/api/generated.ts
@@ -6843,6 +6843,8 @@ export type Vulnerability = {
   cwes: Array<Vulnerability_Vulnerability_Cwe>;
   database_specific?: Maybe<Scalars['jsonb']>;
   details?: Maybe<Scalars['String']>;
+  epss_percentile?: Maybe<Scalars['Float']>;
+  epss_score?: Maybe<Scalars['Float']>;
   /** An array relationship */
   equivalents: Array<Vulnerability_Equivalent>;
   /** An array relationship */
@@ -7278,6 +7280,8 @@ export type Vulnerability_Bool_Exp = {
   cwes?: InputMaybe<Vulnerability_Vulnerability_Cwe_Bool_Exp>;
   database_specific?: InputMaybe<Jsonb_Comparison_Exp>;
   details?: InputMaybe<String_Comparison_Exp>;
+  epss_percentile?: InputMaybe<Float_Comparison_Exp>;
+  epss_score?: InputMaybe<Float_Comparison_Exp>;
   equivalents?: InputMaybe<Vulnerability_Equivalent_Bool_Exp>;
   findings?: InputMaybe<Findings_Bool_Exp>;
   guide_vulnerabilities?: InputMaybe<Guide_Vulnerabilities_Bool_Exp>;
@@ -7473,6 +7477,8 @@ export type Vulnerability_Order_By = {
   cwes_aggregate?: InputMaybe<Vulnerability_Vulnerability_Cwe_Aggregate_Order_By>;
   database_specific?: InputMaybe<Order_By>;
   details?: InputMaybe<Order_By>;
+  epss_percentile?: InputMaybe<Order_By>;
+  epss_score?: InputMaybe<Order_By>;
   equivalents_aggregate?: InputMaybe<Vulnerability_Equivalent_Aggregate_Order_By>;
   findings_aggregate?: InputMaybe<Findings_Aggregate_Order_By>;
   guide_vulnerabilities_aggregate?: InputMaybe<Guide_Vulnerabilities_Aggregate_Order_By>;
@@ -7636,6 +7642,10 @@ export enum Vulnerability_Select_Column {
   DatabaseSpecific = 'database_specific',
   /** column name */
   Details = 'details',
+  /** column name */
+  EpssPercentile = 'epss_percentile',
+  /** column name */
+  EpssScore = 'epss_score',
   /** column name */
   Id = 'id',
   /** column name */

--- a/lunatrace/bsl/hasura/metadata/databases/lunatrace/tables/vulnerability_vulnerability.yaml
+++ b/lunatrace/bsl/hasura/metadata/databases/lunatrace/tables/vulnerability_vulnerability.yaml
@@ -75,40 +75,44 @@ insert_permissions:
     permission:
       check: {}
       columns:
+        - created_at
+        - cvss_score
+        - database_specific
+        - details
+        - epss_percentile
+        - epss_score
         - id
-        - source
-        - source_id
+        - last_fetched
         - modified
         - published
-        - withdrawn
-        - summary
-        - details
-        - database_specific
-        - upstream_data
-        - cvss_score
         - reviewed_by_source
         - severity_name
-        - last_fetched
-        - created_at
+        - source
+        - source_id
+        - summary
+        - upstream_data
+        - withdrawn
 select_permissions:
   - role: service
     permission:
       columns:
+        - created_at
+        - cvss_score
+        - database_specific
+        - details
+        - epss_percentile
+        - epss_score
         - id
-        - source
-        - source_id
+        - last_fetched
         - modified
         - published
-        - withdrawn
-        - summary
-        - details
-        - database_specific
-        - upstream_data
-        - cvss_score
         - reviewed_by_source
         - severity_name
-        - last_fetched
-        - created_at
+        - source
+        - source_id
+        - summary
+        - upstream_data
+        - withdrawn
       filter: {}
   - role: user
     permission:
@@ -117,6 +121,8 @@ select_permissions:
         - cvss_score
         - database_specific
         - details
+        - epss_percentile
+        - epss_score
         - id
         - last_fetched
         - modified
@@ -133,20 +139,22 @@ update_permissions:
   - role: service
     permission:
       columns:
+        - created_at
+        - cvss_score
+        - database_specific
+        - details
+        - epss_percentile
+        - epss_score
         - id
-        - source
-        - source_id
+        - last_fetched
         - modified
         - published
-        - withdrawn
-        - summary
-        - details
-        - database_specific
-        - upstream_data
-        - cvss_score
         - reviewed_by_source
         - severity_name
-        - last_fetched
-        - created_at
+        - source
+        - source_id
+        - summary
+        - upstream_data
+        - withdrawn
       filter: {}
       check: null

--- a/lunatrace/bsl/hasura/metadata/remote_schemas.yaml
+++ b/lunatrace/bsl/hasura/metadata/remote_schemas.yaml
@@ -14,80 +14,80 @@
       definition:
         schema: |
           type AuthenticatedRepoCloneUrlOutput {
-            url: String
+          	url: String
           }
           scalar JSON
           type Mutation {
-            presignManifestUpload(project_id: UUID!): PresignedUrlResponse
+          	presignManifestUpload(project_id: UUID!): PresignedUrlResponse
           }
           type PresignedUrlResponse {
-            bucket: String!
-            headers: JSON!
-            key: String!
-            url: String!
+          	bucket: String!
+          	headers: JSON!
+          	key: String!
+          	url: String!
           }
           type Query {
-            authenticatedRepoCloneUrl(repoGithubId: Int!): AuthenticatedRepoCloneUrlOutput
-            fakeQueryToHackHasuraBeingABuggyMess: String
-            sbomUrl(buildId: UUID!): String
+          	authenticatedRepoCloneUrl(repoGithubId: Int!): AuthenticatedRepoCloneUrlOutput
+          	fakeQueryToHackHasuraBeingABuggyMess: String
+          	sbomUrl(buildId: UUID!): String
           }
           type SbomUploadUrlOutput {
-            error: Boolean!
-            uploadUrl: UploadUrl
+          	error: Boolean!
+          	uploadUrl: UploadUrl
           }
           scalar UUID
           type UploadUrl {
-            headers: JSON!
-            url: String!
+          	headers: JSON!
+          	url: String!
           }
     - role: service
       definition:
         schema: |
           type AuthenticatedRepoCloneUrlOutput {
-            url: String
+          	url: String
           }
           scalar JSON
           type Mutation {
-            presignManifestUpload(project_id: UUID!): PresignedUrlResponse
+          	presignManifestUpload(project_id: UUID!): PresignedUrlResponse
           }
           type PresignedUrlResponse {
-            bucket: String!
-            headers: JSON!
-            key: String!
-            url: String!
+          	bucket: String!
+          	headers: JSON!
+          	key: String!
+          	url: String!
           }
           type Query {
-            authenticatedRepoCloneUrl(repoGithubId: Int!): AuthenticatedRepoCloneUrlOutput
-            fakeQueryToHackHasuraBeingABuggyMess: String
-            presignSbomUpload(orgId: UUID!, buildId: UUID!): SbomUploadUrlOutput
-            sbomUrl(buildId: UUID!): String
+          	authenticatedRepoCloneUrl(repoGithubId: Int!): AuthenticatedRepoCloneUrlOutput
+          	fakeQueryToHackHasuraBeingABuggyMess: String
+          	presignSbomUpload(orgId: UUID!, buildId: UUID!): SbomUploadUrlOutput
+          	sbomUrl(buildId: UUID!): String
           }
           input SbomUploadUrlInput {
-            orgId: UUID!
-            projectId: UUID!
+          	orgId: UUID!
+          	projectId: UUID!
           }
           type SbomUploadUrlOutput {
-            error: Boolean!
-            uploadUrl: UploadUrl
+          	error: Boolean!
+          	uploadUrl: UploadUrl
           }
           scalar UUID
           type UploadUrl {
-            headers: JSON!
-            url: String!
+          	headers: JSON!
+          	url: String!
           }
     - role: cli
       definition:
         schema: |
           scalar JSON
           type Query {
-            presignSbomUpload(orgId: UUID!, buildId: UUID!): SbomUploadUrlOutput
+          	presignSbomUpload(orgId: UUID!, buildId: UUID!): SbomUploadUrlOutput
           }
           type SbomUploadUrlOutput {
-            error: Boolean!
-            uploadUrl: UploadUrl
+          	error: Boolean!
+          	uploadUrl: UploadUrl
           }
           scalar UUID
           type UploadUrl {
-            headers: JSON!
-            url: String!
+          	headers: JSON!
+          	url: String!
           }

--- a/lunatrace/bsl/hasura/migrations/lunatrace/1671051319901_add_epss_score/down.sql
+++ b/lunatrace/bsl/hasura/migrations/lunatrace/1671051319901_add_epss_score/down.sql
@@ -1,0 +1,19 @@
+-- Remove the epss_score and epss_percentile columns from the vulnerability.vulnerability table
+ALTER TABLE vulnerability.vulnerability
+DROP COLUMN epss_score,
+DROP COLUMN epss_percentile;
+
+DROP INDEX vulnerability_epss_score_idx;
+DROP INDEX vulnerability_epss_percentile_idx;
+
+-- Remove the other new indexes also
+DROP INDEX vulnerability_cvss_score_idx;
+DROP INDEX analysis.analysis_manifest_dependency_edge_id_to_finding_source_version_idx;
+DROP INDEX analysis.analysis_manifest_dependency_edge_id_idx;
+DROP INDEX analysis.analysis_manifest_dependency_edge_result_finding_source_version_idx;
+DROP INDEX vulnerability_cvss_score_idx;
+
+DROP INDEX manifest_dependency_edge_parent_id_idx;
+CREATE INDEX manifest_dependency_edge_parent_id_idx ON manifest_dependency_edge (parent_id);
+
+DROP INDEX manifest_dependency_edge_child_id_idx;

--- a/lunatrace/bsl/hasura/migrations/lunatrace/1671051319901_add_epss_score/up.sql
+++ b/lunatrace/bsl/hasura/migrations/lunatrace/1671051319901_add_epss_score/up.sql
@@ -1,0 +1,33 @@
+-- This simply adds a new column to store the EPSS score alongside the CVE data.
+-- This value will always be between 0.0 and 1.0
+ALTER TABLE vulnerability.vulnerability
+ADD COLUMN epss_score REAL
+CHECK (epss_score >= 0.0 AND epss_score <= 1.0);
+
+CREATE INDEX IF NOT EXISTS vulnerability_epss_score_idx ON vulnerability.vulnerability (epss_score);
+
+-- The EPSS percentile is useful for measuring "relative" to other vulnerabilities, how bad is a given CVE?
+ALTER TABLE vulnerability.vulnerability
+ADD COLUMN epss_percentile REAL
+CHECK (epss_percentile >= 0.0 AND epss_percentile <= 1.0);
+
+CREATE INDEX IF NOT EXISTS vulnerability_epss_percentile_idx ON vulnerability.vulnerability (epss_percentile);
+
+-- Add some other indexes on the vulnerability table that were missing.
+CREATE INDEX IF NOT EXISTS vulnerability_cvss_score_idx ON vulnerability.vulnerability (cvss_score);
+
+CREATE INDEX IF NOT EXISTS analysis_manifest_dependency_edge_id_to_finding_source_version_idx
+ON analysis.manifest_dependency_edge_result (manifest_dependency_edge_id, finding_source_version);
+
+CREATE INDEX IF NOT EXISTS analysis_manifest_dependency_edge_id_idx
+ON analysis.manifest_dependency_edge_result (manifest_dependency_edge_id);
+
+CREATE INDEX IF NOT EXISTS analysis_manifest_dependency_edge_result_finding_source_version_idx
+ON analysis.manifest_dependency_edge_result (finding_source_version);
+
+DROP INDEX manifest_dependency_edge_parent_id_idx;
+CREATE INDEX manifest_dependency_edge_parent_id_idx
+ON manifest_dependency_edge (parent_id) INCLUDE (child_id, id);
+
+CREATE INDEX IF NOT EXISTS manifest_dependency_edge_child_id_idx
+ON manifest_dependency_edge (child_id) INCLUDE (parent_id, id);

--- a/lunatrace/gogen/gql/gen.go
+++ b/lunatrace/gogen/gql/gen.go
@@ -6867,6 +6867,8 @@ type Vulnerability_bool_exp struct {
 	Cwes                    *Vulnerability_vulnerability_cwe_bool_exp `json:"cwes,omitempty"`
 	Database_specific       *Jsonb_comparison_exp                     `json:"database_specific,omitempty"`
 	Details                 *String_comparison_exp                    `json:"details,omitempty"`
+	Epss_percentile         *Float_comparison_exp                     `json:"epss_percentile,omitempty"`
+	Epss_score              *Float_comparison_exp                     `json:"epss_score,omitempty"`
 	Equivalents             *Vulnerability_equivalent_bool_exp        `json:"equivalents,omitempty"`
 	Findings                *Findings_bool_exp                        `json:"findings,omitempty"`
 	Guide_vulnerabilities   *Guide_vulnerabilities_bool_exp           `json:"guide_vulnerabilities,omitempty"`
@@ -6917,6 +6919,12 @@ func (v *Vulnerability_bool_exp) GetDatabase_specific() *Jsonb_comparison_exp {
 
 // GetDetails returns Vulnerability_bool_exp.Details, and is useful for accessing the field via an interface.
 func (v *Vulnerability_bool_exp) GetDetails() *String_comparison_exp { return v.Details }
+
+// GetEpss_percentile returns Vulnerability_bool_exp.Epss_percentile, and is useful for accessing the field via an interface.
+func (v *Vulnerability_bool_exp) GetEpss_percentile() *Float_comparison_exp { return v.Epss_percentile }
+
+// GetEpss_score returns Vulnerability_bool_exp.Epss_score, and is useful for accessing the field via an interface.
+func (v *Vulnerability_bool_exp) GetEpss_score() *Float_comparison_exp { return v.Epss_score }
 
 // GetEquivalents returns Vulnerability_bool_exp.Equivalents, and is useful for accessing the field via an interface.
 func (v *Vulnerability_bool_exp) GetEquivalents() *Vulnerability_equivalent_bool_exp {
@@ -7335,6 +7343,8 @@ type Vulnerability_insert_input struct {
 	Cwes                  *Vulnerability_vulnerability_cwe_arr_rel_insert_input `json:"cwes,omitempty"`
 	Database_specific     *json.RawMessage                                      `json:"database_specific,omitempty"`
 	Details               *string                                               `json:"details,omitempty"`
+	Epss_percentile       *float64                                              `json:"epss_percentile,omitempty"`
+	Epss_score            *float64                                              `json:"epss_score,omitempty"`
 	Equivalents           *Vulnerability_equivalent_arr_rel_insert_input        `json:"equivalents,omitempty"`
 	Findings              *Findings_arr_rel_insert_input                        `json:"findings,omitempty"`
 	Guide_vulnerabilities *Guide_vulnerabilities_arr_rel_insert_input           `json:"guide_vulnerabilities,omitempty"`
@@ -7381,6 +7391,12 @@ func (v *Vulnerability_insert_input) GetDatabase_specific() *json.RawMessage {
 
 // GetDetails returns Vulnerability_insert_input.Details, and is useful for accessing the field via an interface.
 func (v *Vulnerability_insert_input) GetDetails() *string { return v.Details }
+
+// GetEpss_percentile returns Vulnerability_insert_input.Epss_percentile, and is useful for accessing the field via an interface.
+func (v *Vulnerability_insert_input) GetEpss_percentile() *float64 { return v.Epss_percentile }
+
+// GetEpss_score returns Vulnerability_insert_input.Epss_score, and is useful for accessing the field via an interface.
+func (v *Vulnerability_insert_input) GetEpss_score() *float64 { return v.Epss_score }
 
 // GetEquivalents returns Vulnerability_insert_input.Equivalents, and is useful for accessing the field via an interface.
 func (v *Vulnerability_insert_input) GetEquivalents() *Vulnerability_equivalent_arr_rel_insert_input {
@@ -7832,6 +7848,8 @@ const (
 	Vulnerability_update_columnCvssScore        Vulnerability_update_column = "cvss_score"
 	Vulnerability_update_columnDatabaseSpecific Vulnerability_update_column = "database_specific"
 	Vulnerability_update_columnDetails          Vulnerability_update_column = "details"
+	Vulnerability_update_columnEpssPercentile   Vulnerability_update_column = "epss_percentile"
+	Vulnerability_update_columnEpssScore        Vulnerability_update_column = "epss_score"
 	Vulnerability_update_columnId               Vulnerability_update_column = "id"
 	Vulnerability_update_columnLastFetched      Vulnerability_update_column = "last_fetched"
 	Vulnerability_update_columnModified         Vulnerability_update_column = "modified"

--- a/lunatrace/gogen/schema.graphql
+++ b/lunatrace/gogen/schema.graphql
@@ -5476,6 +5476,8 @@ type vulnerability {
     cwes(distinct_on: [vulnerability_vulnerability_cwe_select_column!], limit: Int, offset: Int, order_by: [vulnerability_vulnerability_cwe_order_by!], where: vulnerability_vulnerability_cwe_bool_exp): [vulnerability_vulnerability_cwe!]!
     database_specific(path: String): jsonb
     details: String
+    epss_percentile: Float
+    epss_score: Float
     equivalents(distinct_on: [vulnerability_equivalent_select_column!], limit: Int, offset: Int, order_by: [vulnerability_equivalent_order_by!], where: vulnerability_equivalent_bool_exp): [vulnerability_equivalent!]!
     findings(distinct_on: [findings_select_column!], limit: Int, offset: Int, order_by: [findings_order_by!], where: findings_bool_exp): [findings!]!
     guide_vulnerabilities(distinct_on: [guide_vulnerabilities_select_column!], limit: Int, offset: Int, order_by: [guide_vulnerabilities_order_by!], where: guide_vulnerabilities_bool_exp): [guide_vulnerabilities!]!
@@ -5919,6 +5921,8 @@ input vulnerability_bool_exp {
     cwes: vulnerability_vulnerability_cwe_bool_exp
     database_specific: jsonb_comparison_exp
     details: String_comparison_exp
+    epss_percentile: Float_comparison_exp
+    epss_score: Float_comparison_exp
     equivalents: vulnerability_equivalent_bool_exp
     findings: findings_bool_exp
     guide_vulnerabilities: guide_vulnerabilities_bool_exp
@@ -6228,6 +6232,8 @@ enum vulnerability_equivalent_update_column {
 
 input vulnerability_inc_input {
     cvss_score: Float
+    epss_percentile: Float
+    epss_score: Float
 }
 
 input vulnerability_insert_input {
@@ -6238,6 +6244,8 @@ input vulnerability_insert_input {
     cwes: vulnerability_vulnerability_cwe_arr_rel_insert_input
     database_specific: jsonb
     details: String
+    epss_percentile: Float
+    epss_score: Float
     equivalents: vulnerability_equivalent_arr_rel_insert_input
     findings: findings_arr_rel_insert_input
     guide_vulnerabilities: guide_vulnerabilities_arr_rel_insert_input
@@ -6280,6 +6288,8 @@ input vulnerability_order_by {
     cwes_aggregate: vulnerability_vulnerability_cwe_aggregate_order_by
     database_specific: order_by
     details: order_by
+    epss_percentile: order_by
+    epss_score: order_by
     equivalents_aggregate: vulnerability_equivalent_aggregate_order_by
     findings_aggregate: findings_aggregate_order_by
     guide_vulnerabilities_aggregate: guide_vulnerabilities_aggregate_order_by
@@ -6515,6 +6525,8 @@ enum vulnerability_select_column {
     cvss_score
     database_specific
     details
+    epss_percentile
+    epss_score
     id
     last_fetched
     modified
@@ -6533,6 +6545,8 @@ input vulnerability_set_input {
     cvss_score: Float
     database_specific: jsonb
     details: String
+    epss_percentile: Float
+    epss_score: Float
     id: uuid
     last_fetched: timestamptz
     modified: timestamptz
@@ -6661,6 +6675,8 @@ enum vulnerability_update_column {
     cvss_score
     database_specific
     details
+    epss_percentile
+    epss_score
     id
     last_fetched
     modified


### PR DESCRIPTION
Before:
`Execution Time: 8877.799 ms`

After:
`Execution Time: 107.103 ms`

This is mostly because of the indexes on `analysis.manifest_dependency_edge_result`. The others help a bit though.