### PR TITLE
wget is not used currently

### DIFF
--- a/lunatrace/bsl/hasura/Dockerfile
+++ b/lunatrace/bsl/hasura/Dockerfile
@@ -1,6 +1,6 @@
 FROM hasura/graphql-engine:v2.9.0.cli-migrations-v3
 
-RUN apt install wget -y
+#RUN apt install wget -y
 
 ENV HASURA_GRAPHQL_METADATA_DIR /hasura/metadata
 #ENV HASURA_GRAPHQL_MIGRATIONS_DIR /hasura/migrations


### PR DESCRIPTION
```sh
The following NEW packages will be installed:
  libpcre2-8-0 libpsl5 publicsuffix wget
0 upgraded, 4 newly installed, 0 to remove and 21 not upgraded.
Need to get 1293 kB of archives.
After this operation, 4355 kB of additional disk space will be used.
Get:1 http://deb.debian.org/debian buster/main amd64 libpcre2-8-0 amd64 10.32-5 [213 kB]
Get:2 http://deb.debian.org/debian buster/main amd64 libpsl5 amd64 0.20.2-2 [53.7 kB]
Get:3 http://deb.debian.org/debian buster/main amd64 wget amd64 1.20.1-1.1 [902 kB]
Err:4 http://deb.debian.org/debian buster/main amd64 publicsuffix all 20211109.1735-0+deb10u1
  404  Not Found [IP: 151.101.22.132 80]
Fetched 1168 kB in 0s (2453 kB/s)
E: Failed to fetch http://deb.debian.org/debian/pool/main/p/publicsuffix/publicsuffix_20211109.1735-0+deb10u1_all.deb  404  Not Found [IP: 151.101.22.132 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
The command '/bin/sh -c apt install wget -y' returned a non-zero code: 100
[40%] fail: docker build --tag cdkasset-2a8a40fc30a903c7b887ba1d7421655a8d82fc3c3cf85d3286207b8c050f2221 . exited with error code 100: The command '/bin/sh -c apt install wget -y' return
ed a non-zero code: 100
```