### PR TITLE
Add CISA Known Vulnerabilities Ingester

### DIFF
--- a/lunatrace/bsl/hasura/metadata/databases/lunatrace/tables/tables.yaml
+++ b/lunatrace/bsl/hasura/metadata/databases/lunatrace/tables/tables.yaml
@@ -42,7 +42,7 @@
 - "!include vulnerability_affected.yaml"
 - "!include vulnerability_affected_range_event.yaml"
 - "!include vulnerability_affected_version.yaml"
-- "!include vulnerability_cisa_known_exploited_vulnerabilities.yaml"
+- "!include vulnerability_cisa_known_exploited.yaml"
 - "!include vulnerability_credit.yaml"
 - "!include vulnerability_cwe.yaml"
 - "!include vulnerability_equivalent.yaml"

--- a/lunatrace/bsl/hasura/metadata/databases/lunatrace/tables/vulnerability_cisa_known_exploited.yaml
+++ b/lunatrace/bsl/hasura/metadata/databases/lunatrace/tables/vulnerability_cisa_known_exploited.yaml
@@ -1,0 +1,3 @@
+table:
+  name: cisa_known_exploited
+  schema: vulnerability

--- a/lunatrace/bsl/hasura/metadata/databases/lunatrace/tables/vulnerability_cisa_known_exploited_vulnerabilities.yaml
+++ b/lunatrace/bsl/hasura/metadata/databases/lunatrace/tables/vulnerability_cisa_known_exploited_vulnerabilities.yaml
@@ -1,3 +1,0 @@
-table:
-  name: cisa_known_exploited_vulnerabilities
-  schema: vulnerability

--- a/lunatrace/bsl/hasura/migrations/lunatrace/1672788403469_add_cisa_known_exploited_vulnerabilities/down.sql
+++ b/lunatrace/bsl/hasura/migrations/lunatrace/1672788403469_add_cisa_known_exploited_vulnerabilities/down.sql
@@ -1,5 +1,5 @@
 
-DROP TABLE IF EXISTS vulnerability.cisa_known_exploited_vulnerabilities CASCADE;
+DROP TABLE IF EXISTS vulnerability.cisa_known_exploited CASCADE;
 DROP INDEX IF EXISTS vulnerability_vulnerability_cisa_known_exploited_cve_idx;
 
 ALTER TABLE vulnerability.vulnerability DROP COLUMN IF EXISTS cisa_known_exploited_cve;

--- a/lunatrace/bsl/hasura/migrations/lunatrace/1672788403469_add_cisa_known_exploited_vulnerabilities/up.sql
+++ b/lunatrace/bsl/hasura/migrations/lunatrace/1672788403469_add_cisa_known_exploited_vulnerabilities/up.sql
@@ -4,7 +4,7 @@ CREATE INDEX IF NOT EXISTS vulnerability_equivalent_b_idx ON vulnerability.equiv
 CREATE INDEX IF NOT EXISTS vulnerability_vulnerability_source_id_idx ON vulnerability.vulnerability (source_id);
 
 -- Table to hold the CISA Known Exploited vulnerabilities
-CREATE TABLE IF NOT EXISTS vulnerability.cisa_known_exploited_vulnerabilities (
+CREATE TABLE IF NOT EXISTS vulnerability.cisa_known_exploited (
     cve TEXT PRIMARY KEY,
     vendor_project text NOT NULL,
     product text NOT NULL,
@@ -20,6 +20,6 @@ CREATE TABLE IF NOT EXISTS vulnerability.cisa_known_exploited_vulnerabilities (
 -- Reference the CISA Known Exploited vulnerabilities table by CVE
 ALTER TABLE vulnerability.vulnerability
     ADD COLUMN IF NOT EXISTS cisa_known_exploited_cve TEXT
-        REFERENCES vulnerability.cisa_known_exploited_vulnerabilities(cve);
+        REFERENCES vulnerability.cisa_known_exploited(cve);
         
 CREATE INDEX IF NOT EXISTS vulnerability_vulnerability_cisa_known_exploited_cve_idx ON vulnerability.vulnerability (cisa_known_exploited_cve);

--- a/lunatrace/bsl/ingest-worker/cmd/ingestworker/cisa/cisa.go
+++ b/lunatrace/bsl/ingest-worker/cmd/ingestworker/cisa/cisa.go
@@ -1,0 +1,51 @@
+// Copyright by LunaSec (owned by Refinery Labs, Inc)
+//
+// Licensed under the Business Source License v1.1
+// (the "License"); you may not use this file except in compliance with the
+// License. You may obtain a copy of the License at
+//
+// https://github.com/lunasec-io/lunasec/blob/master/licenses/BSL-LunaTrace.txt
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cisa
+
+import (
+  "github.com/ajvpot/clifx"
+  "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/cisa"
+  "github.com/rs/zerolog/log"
+  "github.com/urfave/cli/v2"
+  "go.uber.org/fx"
+)
+
+type Params struct {
+  fx.In
+
+  Ingester cisa.CISAKnownVulnIngester
+}
+
+func NewCommand(p Params) clifx.CommandResult {
+  return clifx.CommandResult{
+    Command: &cli.Command{
+      Name: "cisa",
+      Subcommands: []*cli.Command{
+        {
+          Name:        "ingest",
+          Usage:       "[file or directory]",
+          Flags:       []cli.Flag{},
+          Subcommands: []*cli.Command{},
+          Action: func(ctx *cli.Context) error {
+            log.Info().
+              Msg("Updating CISA Known Vulnerabilities")
+            err := p.Ingester.Ingest(ctx.Context)
+            if err == nil {
+              log.Info().
+                Msg("Updated CISA Known Vulnerabilities")
+            }
+            return err
+          },
+        },
+      },
+    },
+  }
+}

--- a/lunatrace/bsl/ingest-worker/cmd/ingestworker/cisa/cisa.go
+++ b/lunatrace/bsl/ingest-worker/cmd/ingestworker/cisa/cisa.go
@@ -11,41 +11,41 @@
 package cisa
 
 import (
-  "github.com/ajvpot/clifx"
-  "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/cisa"
-  "github.com/rs/zerolog/log"
-  "github.com/urfave/cli/v2"
-  "go.uber.org/fx"
+	"github.com/ajvpot/clifx"
+	"github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/cisa"
+	"github.com/rs/zerolog/log"
+	"github.com/urfave/cli/v2"
+	"go.uber.org/fx"
 )
 
 type Params struct {
-  fx.In
+	fx.In
 
-  Ingester cisa.CISAKnownVulnIngester
+	Ingester cisa.CISAKnownVulnIngester
 }
 
 func NewCommand(p Params) clifx.CommandResult {
-  return clifx.CommandResult{
-    Command: &cli.Command{
-      Name: "cisa",
-      Subcommands: []*cli.Command{
-        {
-          Name:        "ingest",
-          Usage:       "[file or directory]",
-          Flags:       []cli.Flag{},
-          Subcommands: []*cli.Command{},
-          Action: func(ctx *cli.Context) error {
-            log.Info().
-              Msg("Updating CISA Known Vulnerabilities")
-            err := p.Ingester.Ingest(ctx.Context)
-            if err == nil {
-              log.Info().
-                Msg("Updated CISA Known Vulnerabilities")
-            }
-            return err
-          },
-        },
-      },
-    },
-  }
+	return clifx.CommandResult{
+		Command: &cli.Command{
+			Name: "cisa",
+			Subcommands: []*cli.Command{
+				{
+					Name:        "ingest",
+					Usage:       "[file or directory]",
+					Flags:       []cli.Flag{},
+					Subcommands: []*cli.Command{},
+					Action: func(ctx *cli.Context) error {
+						log.Info().
+							Msg("Updating CISA Known Vulnerabilities")
+						err := p.Ingester.Ingest(ctx.Context)
+						if err == nil {
+							log.Info().
+								Msg("Updated CISA Known Vulnerabilities")
+						}
+						return err
+					},
+				},
+			},
+		},
+	}
 }

--- a/lunatrace/bsl/ingest-worker/cmd/ingestworker/main.go
+++ b/lunatrace/bsl/ingest-worker/cmd/ingestworker/main.go
@@ -11,80 +11,80 @@
 package main
 
 import (
-  "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/cmd/ingestworker/cisa"
-  "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/cmd/ingestworker/cwe"
-  "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/cmd/ingestworker/epss"
-  packageCommand "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/cmd/ingestworker/package"
-  "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/cmd/ingestworker/vulnerability"
-  cisa2 "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/cisa"
-  "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/config/ingestworker"
-  cwe2 "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/cwe"
-  "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/dbfx"
-  epss2 "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/epss"
-  "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/graphqlfx"
-  "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/metadata/registry"
-  "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/metadata/replicator"
-  "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/scanner/licensecheck"
-  "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/scanner/packagejson"
-  "github.com/rs/zerolog"
-  "github.com/rs/zerolog/log"
-  "net/http"
-  "os"
+	"github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/cmd/ingestworker/cisa"
+	"github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/cmd/ingestworker/cwe"
+	"github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/cmd/ingestworker/epss"
+	packageCommand "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/cmd/ingestworker/package"
+	"github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/cmd/ingestworker/vulnerability"
+	cisa2 "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/cisa"
+	"github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/config/ingestworker"
+	cwe2 "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/cwe"
+	"github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/dbfx"
+	epss2 "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/epss"
+	"github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/graphqlfx"
+	"github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/metadata/registry"
+	"github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/metadata/replicator"
+	"github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/scanner/licensecheck"
+	"github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/scanner/packagejson"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"net/http"
+	"os"
 
-  "go.uber.org/fx"
+	"go.uber.org/fx"
 
-  clifx2 "github.com/ajvpot/clifx"
+	clifx2 "github.com/ajvpot/clifx"
 
-  "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/cmd/ingestworker/license"
-  "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/metadata/ingester"
-  vulnmanager "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/vulnerability"
+	"github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/cmd/ingestworker/license"
+	"github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/metadata/ingester"
+	vulnmanager "github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/vulnerability"
 )
 
 func main() {
-  // TODO (cthompson) this should be configured with an fx module
-  log.Logger = zerolog.New(os.Stderr).With().Timestamp().Logger()
+	// TODO (cthompson) this should be configured with an fx module
+	log.Logger = zerolog.New(os.Stderr).With().Timestamp().Logger()
 
-  clifx2.Main(
-    fx.Supply(http.DefaultClient),
+	clifx2.Main(
+		fx.Supply(http.DefaultClient),
 
-    graphqlfx.Module,
-    dbfx.Module,
-    registry.NPMModule,
+		graphqlfx.Module,
+		dbfx.Module,
+		registry.NPMModule,
 
-    fx.Provide(
-      cwe2.NewCWEIngester,
-      epss2.NewEPSSIngester,
-      cisa2.NewCISAKnownVulnIngester,
-    ),
+		fx.Provide(
+			cwe2.NewCWEIngester,
+			epss2.NewEPSSIngester,
+			cisa2.NewCISAKnownVulnIngester,
+		),
 
-    // todo make a module
-    fx.Supply(&clifx2.AppConfig{
-      Name:    "ingestworker",
-      Usage:   "LunaTrace Ingest Worker",
-      Version: "0.0.1",
-    }),
-    fx.Provide(
-      ingester.NewPackageSqlIngester,
-      ingester.NewNPMPackageIngester,
-      replicator.NewNPMReplicator,
-    ),
-    fx.Provide(
-      ingestworker.NewConfigProvider,
-    ),
-    fx.Provide(
-      licensecheck.NewScanner,
-      packagejson.NewScanner,
-      license.NewCommand,
-      vulnmanager.NewFileIngester,
-    ),
-    fx.Provide(
-      vulnerability.NewCommand,
-      cwe.NewCommand,
-      epss.NewCommand,
-      cisa.NewCommand,
-    ),
-    fx.Provide(
-      packageCommand.NewCommand,
-    ),
-  )
+		// todo make a module
+		fx.Supply(&clifx2.AppConfig{
+			Name:    "ingestworker",
+			Usage:   "LunaTrace Ingest Worker",
+			Version: "0.0.1",
+		}),
+		fx.Provide(
+			ingester.NewPackageSqlIngester,
+			ingester.NewNPMPackageIngester,
+			replicator.NewNPMReplicator,
+		),
+		fx.Provide(
+			ingestworker.NewConfigProvider,
+		),
+		fx.Provide(
+			licensecheck.NewScanner,
+			packagejson.NewScanner,
+			license.NewCommand,
+			vulnmanager.NewFileIngester,
+		),
+		fx.Provide(
+			vulnerability.NewCommand,
+			cwe.NewCommand,
+			epss.NewCommand,
+			cisa.NewCommand,
+		),
+		fx.Provide(
+			packageCommand.NewCommand,
+		),
+	)
 }

--- a/lunatrace/bsl/ingest-worker/pkg/cisa/fetch.go
+++ b/lunatrace/bsl/ingest-worker/pkg/cisa/fetch.go
@@ -1,0 +1,123 @@
+// Copyright by LunaSec (owned by Refinery Labs, Inc)
+//
+// Licensed under the Business Source License v1.1
+// (the "License"); you may not use this file except in compliance with the
+// License. You may obtain a copy of the License at
+//
+// https://github.com/lunasec-io/lunasec/blob/master/licenses/BSL-LunaTrace.txt
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cisa
+
+import (
+  "bytes"
+  "encoding/csv"
+  "fmt"
+  "github.com/rs/zerolog/log"
+  "io"
+  "net/http"
+  "regexp"
+)
+
+// CisaKnownVulnerability represents a single row in the CISA CSV file
+// "cveID","vendorProject","product","vulnerabilityName","dateAdded","shortDescription","requiredAction","dueDate","notes"
+type CisaKnownVulnerability struct {
+  Cve               string
+  VendorProject     string
+  Product           string
+  VulnerabilityName string
+  DateAdded         string
+  ShortDescription  string
+  RequiredAction    string
+  DueDate           string
+  Notes             string
+}
+
+func FetchCisaKnownVulns() ([]CisaKnownVulnerability, error) {
+  // Download the file
+  response, err := http.Get("https://www.cisa.gov/sites/default/files/csv/known_exploited_vulnerabilities.csv")
+  if err != nil {
+    fmt.Printf("Error downloading CISA file: %v\n", err)
+    return nil, err
+  }
+  defer response.Body.Close()
+
+  body, err := io.ReadAll(response.Body)
+  if err != nil {
+    log.Error().Err(err).Msg("failed to read cwe data")
+    return nil, err
+  }
+
+  buf := bytes.NewReader(body)
+
+  // Create a new CSV reader
+  csvReader := csv.NewReader(buf)
+
+  csvReader.FieldsPerRecord = 9
+
+  // The data looks like this:
+  // "cveID","vendorProject","product","vulnerabilityName","dateAdded","shortDescription","requiredAction","dueDate","notes"
+  // "CVE-2021-27104","vendor","prod","vuln_name","2021-11-03","description","action","2021-11-17",""
+
+  // Read the first header row
+  _, err = csvReader.Read()
+  if err != nil {
+    fmt.Printf("Error reading CSV header: %v\n", err)
+    return nil, err
+  }
+
+  // Read the rest of the rows
+  rows, err := csvReader.ReadAll()
+  if err != nil {
+    fmt.Printf("Error reading CSV rows: %v\n", err)
+    return nil, err
+  }
+
+  // Regex to verify that cvePair.Cve is a valid CVE
+  cveRegex, err := regexp.Compile(`^CVE-\d{4}-\d+$`)
+
+  dateRegex, err := regexp.Compile(`^\d{4}-\d{2}-\d{2}$`)
+
+  cisaScores := make([]CisaKnownVulnerability, 0, len(rows))
+
+  // Create an array of EpssVulnerability objects
+  for _, row := range rows {
+    cve := row[0]
+    vendorProject := row[1]
+    product := row[2]
+    vulnerabilityName := row[3]
+    dateAdded := row[4]
+    shortDescription := row[5]
+    requiredAction := row[6]
+    dueDate := row[7]
+    notes := row[8]
+
+    // Validates that the CVE is not a SQL injection payload :)
+    if !cveRegex.MatchString(cve) {
+      return nil, fmt.Errorf("invalid cve %s", cve)
+    }
+
+    if !dateRegex.MatchString(dateAdded) {
+      return nil, fmt.Errorf("invalid added date %s", dateAdded)
+    }
+
+    if !dateRegex.MatchString(dueDate) {
+      return nil, fmt.Errorf("invalid due date %s", dueDate)
+    }
+
+    cisaScores = append(cisaScores, CisaKnownVulnerability{
+      Cve:               cve,
+      VendorProject:     vendorProject,
+      Product:           product,
+      VulnerabilityName: vulnerabilityName,
+      DateAdded:         dateAdded,
+      ShortDescription:  shortDescription,
+      RequiredAction:    requiredAction,
+      DueDate:           dueDate,
+      Notes:             notes,
+    })
+  }
+
+  return cisaScores, nil
+}

--- a/lunatrace/bsl/ingest-worker/pkg/cisa/fetch.go
+++ b/lunatrace/bsl/ingest-worker/pkg/cisa/fetch.go
@@ -11,113 +11,113 @@
 package cisa
 
 import (
-  "bytes"
-  "encoding/csv"
-  "fmt"
-  "github.com/rs/zerolog/log"
-  "io"
-  "net/http"
-  "regexp"
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"github.com/rs/zerolog/log"
+	"io"
+	"net/http"
+	"regexp"
 )
 
 // CisaKnownVulnerability represents a single row in the CISA CSV file
 // "cveID","vendorProject","product","vulnerabilityName","dateAdded","shortDescription","requiredAction","dueDate","notes"
 type CisaKnownVulnerability struct {
-  Cve               string
-  VendorProject     string
-  Product           string
-  VulnerabilityName string
-  DateAdded         string
-  ShortDescription  string
-  RequiredAction    string
-  DueDate           string
-  Notes             string
+	Cve               string
+	VendorProject     string
+	Product           string
+	VulnerabilityName string
+	DateAdded         string
+	ShortDescription  string
+	RequiredAction    string
+	DueDate           string
+	Notes             string
 }
 
 func FetchCisaKnownVulns() ([]CisaKnownVulnerability, error) {
-  // Download the file
-  response, err := http.Get("https://www.cisa.gov/sites/default/files/csv/known_exploited_vulnerabilities.csv")
-  if err != nil {
-    fmt.Printf("Error downloading CISA file: %v\n", err)
-    return nil, err
-  }
-  defer response.Body.Close()
+	// Download the file
+	response, err := http.Get("https://www.cisa.gov/sites/default/files/csv/known_exploited_vulnerabilities.csv")
+	if err != nil {
+		fmt.Printf("Error downloading CISA file: %v\n", err)
+		return nil, err
+	}
+	defer response.Body.Close()
 
-  body, err := io.ReadAll(response.Body)
-  if err != nil {
-    log.Error().Err(err).Msg("failed to read cwe data")
-    return nil, err
-  }
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read cwe data")
+		return nil, err
+	}
 
-  buf := bytes.NewReader(body)
+	buf := bytes.NewReader(body)
 
-  // Create a new CSV reader
-  csvReader := csv.NewReader(buf)
+	// Create a new CSV reader
+	csvReader := csv.NewReader(buf)
 
-  csvReader.FieldsPerRecord = 9
+	csvReader.FieldsPerRecord = 9
 
-  // The data looks like this:
-  // "cveID","vendorProject","product","vulnerabilityName","dateAdded","shortDescription","requiredAction","dueDate","notes"
-  // "CVE-2021-27104","vendor","prod","vuln_name","2021-11-03","description","action","2021-11-17",""
+	// The data looks like this:
+	// "cveID","vendorProject","product","vulnerabilityName","dateAdded","shortDescription","requiredAction","dueDate","notes"
+	// "CVE-2021-27104","vendor","prod","vuln_name","2021-11-03","description","action","2021-11-17",""
 
-  // Read the first header row
-  _, err = csvReader.Read()
-  if err != nil {
-    fmt.Printf("Error reading CSV header: %v\n", err)
-    return nil, err
-  }
+	// Read the first header row
+	_, err = csvReader.Read()
+	if err != nil {
+		fmt.Printf("Error reading CSV header: %v\n", err)
+		return nil, err
+	}
 
-  // Read the rest of the rows
-  rows, err := csvReader.ReadAll()
-  if err != nil {
-    fmt.Printf("Error reading CSV rows: %v\n", err)
-    return nil, err
-  }
+	// Read the rest of the rows
+	rows, err := csvReader.ReadAll()
+	if err != nil {
+		fmt.Printf("Error reading CSV rows: %v\n", err)
+		return nil, err
+	}
 
-  // Regex to verify that cvePair.Cve is a valid CVE
-  cveRegex, err := regexp.Compile(`^CVE-\d{4}-\d+$`)
+	// Regex to verify that cvePair.Cve is a valid CVE
+	cveRegex, err := regexp.Compile(`^CVE-\d{4}-\d+$`)
 
-  dateRegex, err := regexp.Compile(`^\d{4}-\d{2}-\d{2}$`)
+	dateRegex, err := regexp.Compile(`^\d{4}-\d{2}-\d{2}$`)
 
-  cisaScores := make([]CisaKnownVulnerability, 0, len(rows))
+	cisaScores := make([]CisaKnownVulnerability, 0, len(rows))
 
-  // Create an array of EpssVulnerability objects
-  for _, row := range rows {
-    cve := row[0]
-    vendorProject := row[1]
-    product := row[2]
-    vulnerabilityName := row[3]
-    dateAdded := row[4]
-    shortDescription := row[5]
-    requiredAction := row[6]
-    dueDate := row[7]
-    notes := row[8]
+	// Create an array of EpssVulnerability objects
+	for _, row := range rows {
+		cve := row[0]
+		vendorProject := row[1]
+		product := row[2]
+		vulnerabilityName := row[3]
+		dateAdded := row[4]
+		shortDescription := row[5]
+		requiredAction := row[6]
+		dueDate := row[7]
+		notes := row[8]
 
-    // Validates that the CVE is not a SQL injection payload :)
-    if !cveRegex.MatchString(cve) {
-      return nil, fmt.Errorf("invalid cve %s", cve)
-    }
+		// Validates that the CVE is not a SQL injection payload :)
+		if !cveRegex.MatchString(cve) {
+			return nil, fmt.Errorf("invalid cve %s", cve)
+		}
 
-    if !dateRegex.MatchString(dateAdded) {
-      return nil, fmt.Errorf("invalid added date %s", dateAdded)
-    }
+		if !dateRegex.MatchString(dateAdded) {
+			return nil, fmt.Errorf("invalid added date %s", dateAdded)
+		}
 
-    if !dateRegex.MatchString(dueDate) {
-      return nil, fmt.Errorf("invalid due date %s", dueDate)
-    }
+		if !dateRegex.MatchString(dueDate) {
+			return nil, fmt.Errorf("invalid due date %s", dueDate)
+		}
 
-    cisaScores = append(cisaScores, CisaKnownVulnerability{
-      Cve:               cve,
-      VendorProject:     vendorProject,
-      Product:           product,
-      VulnerabilityName: vulnerabilityName,
-      DateAdded:         dateAdded,
-      ShortDescription:  shortDescription,
-      RequiredAction:    requiredAction,
-      DueDate:           dueDate,
-      Notes:             notes,
-    })
-  }
+		cisaScores = append(cisaScores, CisaKnownVulnerability{
+			Cve:               cve,
+			VendorProject:     vendorProject,
+			Product:           product,
+			VulnerabilityName: vulnerabilityName,
+			DateAdded:         dateAdded,
+			ShortDescription:  shortDescription,
+			RequiredAction:    requiredAction,
+			DueDate:           dueDate,
+			Notes:             notes,
+		})
+	}
 
-  return cisaScores, nil
+	return cisaScores, nil
 }

--- a/lunatrace/bsl/ingest-worker/pkg/cisa/fetch_test.go
+++ b/lunatrace/bsl/ingest-worker/pkg/cisa/fetch_test.go
@@ -11,26 +11,26 @@
 package cisa
 
 import (
-  "github.com/stretchr/testify/assert"
-  "testing"
+	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestFetchEpssScores(t *testing.T) {
-  cisaKnownVulns, err := FetchCisaKnownVulns()
-  assert.Nil(t, err, "error should not be defined when downloading cisa scores")
-  assert.Greater(t, len(cisaKnownVulns), 0, "there should be more than zero cisaKnownVulns in list")
+	cisaKnownVulns, err := FetchCisaKnownVulns()
+	assert.Nil(t, err, "error should not be defined when downloading cisa scores")
+	assert.Greater(t, len(cisaKnownVulns), 0, "there should be more than zero cisaKnownVulns in list")
 
-  // Check that the first cisa score is valid and begins with "CVE-"
-  assert.Greater(t, len(cisaKnownVulns[0].Cve), 10, "cve should be at least 10 characters long")
-  assert.Equal(t, "CVE-", cisaKnownVulns[0].Cve[0:4], "cve should begin with CVE-*")
+	// Check that the first cisa score is valid and begins with "CVE-"
+	assert.Greater(t, len(cisaKnownVulns[0].Cve), 10, "cve should be at least 10 characters long")
+	assert.Equal(t, "CVE-", cisaKnownVulns[0].Cve[0:4], "cve should begin with CVE-*")
 
-  assert.Greater(t, len(cisaKnownVulns[0].VendorProject), 0, "vendor project should be at least 1 characters long")
-  assert.Greater(t, len(cisaKnownVulns[0].Product), 0, "product should be at least 1 characters long")
-  assert.Greater(t, len(cisaKnownVulns[0].VulnerabilityName), 0, "vulnerability name should be at least 1 characters long")
-  assert.Equal(t, len(cisaKnownVulns[0].DateAdded), 10, "date added should be 10 characters long")
-  assert.Greater(t, len(cisaKnownVulns[0].ShortDescription), 0, "short description should be at least 1 characters long")
-  assert.GreaterOrEqual(t, len(cisaKnownVulns[0].RequiredAction), 0, "required action should be at least 0 characters long")
-  assert.Equal(t, len(cisaKnownVulns[0].DueDate), 10, "due date should be 10 characters long")
-  assert.GreaterOrEqual(t, len(cisaKnownVulns[0].Notes), 0, "notes should be at least 0 characters long")
+	assert.Greater(t, len(cisaKnownVulns[0].VendorProject), 0, "vendor project should be at least 1 characters long")
+	assert.Greater(t, len(cisaKnownVulns[0].Product), 0, "product should be at least 1 characters long")
+	assert.Greater(t, len(cisaKnownVulns[0].VulnerabilityName), 0, "vulnerability name should be at least 1 characters long")
+	assert.Equal(t, len(cisaKnownVulns[0].DateAdded), 10, "date added should be 10 characters long")
+	assert.Greater(t, len(cisaKnownVulns[0].ShortDescription), 0, "short description should be at least 1 characters long")
+	assert.GreaterOrEqual(t, len(cisaKnownVulns[0].RequiredAction), 0, "required action should be at least 0 characters long")
+	assert.Equal(t, len(cisaKnownVulns[0].DueDate), 10, "due date should be 10 characters long")
+	assert.GreaterOrEqual(t, len(cisaKnownVulns[0].Notes), 0, "notes should be at least 0 characters long")
 
 }

--- a/lunatrace/bsl/ingest-worker/pkg/cisa/fetch_test.go
+++ b/lunatrace/bsl/ingest-worker/pkg/cisa/fetch_test.go
@@ -1,0 +1,36 @@
+// Copyright by LunaSec (owned by Refinery Labs, Inc)
+//
+// Licensed under the Business Source License v1.1
+// (the "License"); you may not use this file except in compliance with the
+// License. You may obtain a copy of the License at
+//
+// https://github.com/lunasec-io/lunasec/blob/master/licenses/BSL-LunaTrace.txt
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cisa
+
+import (
+  "github.com/stretchr/testify/assert"
+  "testing"
+)
+
+func TestFetchEpssScores(t *testing.T) {
+  cisaKnownVulns, err := FetchCisaKnownVulns()
+  assert.Nil(t, err, "error should not be defined when downloading cisa scores")
+  assert.Greater(t, len(cisaKnownVulns), 0, "there should be more than zero cisaKnownVulns in list")
+
+  // Check that the first cisa score is valid and begins with "CVE-"
+  assert.Greater(t, len(cisaKnownVulns[0].Cve), 10, "cve should be at least 10 characters long")
+  assert.Equal(t, "CVE-", cisaKnownVulns[0].Cve[0:4], "cve should begin with CVE-*")
+
+  assert.Greater(t, len(cisaKnownVulns[0].VendorProject), 0, "vendor project should be at least 1 characters long")
+  assert.Greater(t, len(cisaKnownVulns[0].Product), 0, "product should be at least 1 characters long")
+  assert.Greater(t, len(cisaKnownVulns[0].VulnerabilityName), 0, "vulnerability name should be at least 1 characters long")
+  assert.Equal(t, len(cisaKnownVulns[0].DateAdded), 10, "date added should be 10 characters long")
+  assert.Greater(t, len(cisaKnownVulns[0].ShortDescription), 0, "short description should be at least 1 characters long")
+  assert.GreaterOrEqual(t, len(cisaKnownVulns[0].RequiredAction), 0, "required action should be at least 0 characters long")
+  assert.Equal(t, len(cisaKnownVulns[0].DueDate), 10, "due date should be 10 characters long")
+  assert.GreaterOrEqual(t, len(cisaKnownVulns[0].Notes), 0, "notes should be at least 0 characters long")
+
+}

--- a/lunatrace/bsl/ingest-worker/pkg/cisa/ingester.go
+++ b/lunatrace/bsl/ingest-worker/pkg/cisa/ingester.go
@@ -11,28 +11,28 @@
 package cisa
 
 import (
-	"context"
-	"database/sql"
-	"github.com/rs/zerolog/log"
-	"go.uber.org/fx"
+  "context"
+  "database/sql"
+  "github.com/rs/zerolog/log"
+  "go.uber.org/fx"
 )
 
 type CISAKnownVulnIngester interface {
-	Ingest(ctx context.Context) error
+  Ingest(ctx context.Context) error
 }
 
 type CISAKnownVulnIngesterParams struct {
-	fx.In
+  fx.In
 
-	DB *sql.DB
+  DB *sql.DB
 }
 
 type cisaKnownVulnIngester struct {
-	deps CISAKnownVulnIngesterParams
+  deps CISAKnownVulnIngesterParams
 }
 
 // -- Table to hold the CISA Known Exploited vulnerabilities
-// CREATE TABLE IF NOT EXISTS vulnerability.cisa_known_exploited_vulnerabilities (
+// CREATE TABLE IF NOT EXISTS vulnerability.cisa_known_exploited (
 //     cve TEXT PRIMARY KEY,
 //     vendor_project text NOT NULL,
 //     product text NOT NULL,
@@ -48,55 +48,55 @@ type cisaKnownVulnIngester struct {
 // GetKnownCves returns a list of all known CVEs from the database that exist in the CISA Known Exploited Vulnerabilities table
 // Run this query *after* you have inserted all the new CISA Known Exploited Vulnerabilities
 func GetKnownCves(tx *sql.Tx) (map[string]bool, error) {
-	// Query for all the CVEs that are already in the database from the CISA Known Vulnerabilitie
-	result, err := tx.Query(`
-    SELECT cve.id FROM vulnerability.cisa_known_exploited_vulnerabilities cisa
+  // Query for all the CVEs that are already in the database from the CISA Known Vulnerabilitie
+  result, err := tx.Query(`
+    SELECT cve.id FROM vulnerability.cisa_known_exploited cisa
     INNER JOIN vulnerability.vulnerability cve ON cve.source = 'nvd' AND cve.source_id = cisa.cve
   `)
-	if err != nil {
-		log.Error().
-			Err(err).Msg("failed to query for known cves for CISA ingester")
-		return nil, err
-	}
+  if err != nil {
+    log.Error().
+      Err(err).Msg("failed to query for known cves for CISA ingester")
+    return nil, err
+  }
 
-	knownCves := make(map[string]bool)
-	for result.Next() {
-		var cve string
-		err = result.Scan(&cve)
-		if err != nil {
-			log.Error().
-				Err(err).Msg("failed to map cve for CISA ingester")
-			return nil, err
-		}
-		knownCves[cve] = true
-	}
-	return knownCves, nil
+  knownCves := make(map[string]bool)
+  for result.Next() {
+    var cve string
+    err = result.Scan(&cve)
+    if err != nil {
+      log.Error().
+        Err(err).Msg("failed to map cve for CISA ingester")
+      return nil, err
+    }
+    knownCves[cve] = true
+  }
+  return knownCves, nil
 }
 
 func (s *cisaKnownVulnIngester) Ingest(ctx context.Context) error {
 
-	cisaKnownVulns, err := FetchCisaKnownVulns()
-	if err != nil {
-		log.Error().
-			Err(err)
-		return err
-	}
+  cisaKnownVulns, err := FetchCisaKnownVulns()
+  if err != nil {
+    log.Error().
+      Err(err)
+    return err
+  }
 
-	log.Info().
-		Int("count", len(cisaKnownVulns)).
-		Msg("fetched cisa known exploited vulnerabilities")
+  log.Info().
+    Int("count", len(cisaKnownVulns)).
+    Msg("fetched cisa known exploited vulnerabilities")
 
-	tx, err := s.deps.DB.BeginTx(ctx, &sql.TxOptions{
-		Isolation: sql.LevelReadUncommitted,
-	})
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
+  tx, err := s.deps.DB.BeginTx(ctx, &sql.TxOptions{
+    Isolation: sql.LevelReadUncommitted,
+  })
+  if err != nil {
+    return err
+  }
+  defer tx.Rollback()
 
-	for _, cisaKnownVuln := range cisaKnownVulns {
-		_, err = tx.ExecContext(ctx, `
-      INSERT INTO vulnerability.cisa_known_exploited_vulnerabilities (
+  for _, cisaKnownVuln := range cisaKnownVulns {
+    _, err = tx.ExecContext(ctx, `
+      INSERT INTO vulnerability.cisa_known_exploited (
         cve,
         vendor_project,
         product,
@@ -118,98 +118,98 @@ func (s *cisaKnownVulnIngester) Ingest(ctx context.Context) error {
         due_date = $8,
         notes = $9
       `,
-			cisaKnownVuln.Cve,
-			cisaKnownVuln.VendorProject,
-			cisaKnownVuln.Product,
-			cisaKnownVuln.VulnerabilityName,
-			cisaKnownVuln.DateAdded,
-			cisaKnownVuln.ShortDescription,
-			cisaKnownVuln.RequiredAction,
-			cisaKnownVuln.DueDate,
-			cisaKnownVuln.Notes,
-		)
+      cisaKnownVuln.Cve,
+      cisaKnownVuln.VendorProject,
+      cisaKnownVuln.Product,
+      cisaKnownVuln.VulnerabilityName,
+      cisaKnownVuln.DateAdded,
+      cisaKnownVuln.ShortDescription,
+      cisaKnownVuln.RequiredAction,
+      cisaKnownVuln.DueDate,
+      cisaKnownVuln.Notes,
+    )
 
-		if err != nil {
-			log.Error().
-				Err(err).Msg("failed to insert CISA Known Vulnerability")
-			return err
-		}
-	}
+    if err != nil {
+      log.Error().
+        Err(err).Msg("failed to insert CISA Known Vulnerability")
+      return err
+    }
+  }
 
-	knownCves, err := GetKnownCves(tx)
+  knownCves, err := GetKnownCves(tx)
 
-	if err != nil {
-		log.Error().
-			Err(err).Msg("failed to get known CVEs for CISA ingester")
-		return err
-	}
+  if err != nil {
+    log.Error().
+      Err(err).Msg("failed to get known CVEs for CISA ingester")
+    return err
+  }
 
-	log.Info().
-		Int("knownCves", len(knownCves)).
-		Msg("found known CVEs, setting the cisa_known_exploited_cve column")
+  log.Info().
+    Int("knownCves", len(knownCves)).
+    Msg("found known CVEs, setting the cisa_known_exploited_cve column")
 
-	for _, cisaKnownVuln := range cisaKnownVulns {
-		if _, ok := knownCves[cisaKnownVuln.Cve]; ok {
-			continue
-		}
+  for _, cisaKnownVuln := range cisaKnownVulns {
+    if _, ok := knownCves[cisaKnownVuln.Cve]; ok {
+      continue
+    }
 
-		result, err := tx.QueryContext(ctx, `
+    result, err := tx.QueryContext(ctx, `
       SELECT cveeq.* FROM vulnerability.vulnerability cve
         JOIN vulnerability.equivalent cveeq ON cveeq.a = cve.id OR cveeq.b = cve.id
         WHERE cve.source = 'nvd' AND cve.source_id = $1
     `, cisaKnownVuln.Cve)
 
-		if err != nil {
-			log.Error().
-				Err(err).Msg("failed to query for equivalent CVE for CISA ingester")
-			return err
-		}
+    if err != nil {
+      log.Error().
+        Err(err).Msg("failed to query for equivalent CVE for CISA ingester")
+      return err
+    }
 
-		// Generate a list of all vulnerabilities that need to be marked as being a CISA Known Exploited Vulnerability
-		cveIds := make(map[string]bool)
-		for result.Next() {
-			var cveA string
-			var cveB string
-			err = result.Scan(&cveA, &cveB)
-			if err != nil {
-				log.Error().
-					Err(err).Msg("failed to map equivalent CVE for CISA ingester")
-				return err
-			}
+    // Generate a list of all vulnerabilities that need to be marked as being a CISA Known Exploited Vulnerability
+    cveIds := make(map[string]bool)
+    for result.Next() {
+      var cveA string
+      var cveB string
+      err = result.Scan(&cveA, &cveB)
+      if err != nil {
+        log.Error().
+          Err(err).Msg("failed to map equivalent CVE for CISA ingester")
+        return err
+      }
 
-			// add the CVEs to the map to ensure no duplicates
-			cveIds[cveA] = true
-			cveIds[cveB] = true
-		}
+      // add the CVEs to the map to ensure no duplicates
+      cveIds[cveA] = true
+      cveIds[cveB] = true
+    }
 
-		// Sets the CISA Known Exploited Vulnerability column for CVEs in the vulnerability table
-		for cveId := range cveIds {
-			_, err = tx.ExecContext(ctx, `
+    // Sets the CISA Known Exploited Vulnerability column for CVEs in the vulnerability table
+    for cveId := range cveIds {
+      _, err = tx.ExecContext(ctx, `
         UPDATE vulnerability.vulnerability SET
           cisa_known_exploited_cve = $1
         WHERE id = $2
       `, cisaKnownVuln.Cve, cveId)
 
-			if err != nil {
-				log.Error().
-					Err(err).Msg("failed to insert CISA Known Vulnerability")
-				return err
-			}
-		}
-	}
+      if err != nil {
+        log.Error().
+          Err(err).Msg("failed to insert CISA Known Vulnerability")
+        return err
+      }
+    }
+  }
 
-	log.Info().
-		Msg("committing cisa known vulns")
+  log.Info().
+    Msg("committing cisa known vulns")
 
-	if err = tx.Commit(); err != nil {
-		return err
-	}
+  if err = tx.Commit(); err != nil {
+    return err
+  }
 
-	return nil
+  return nil
 }
 
 func NewCISAKnownVulnIngester(params CISAKnownVulnIngesterParams) CISAKnownVulnIngester {
-	return &cisaKnownVulnIngester{
-		params,
-	}
+  return &cisaKnownVulnIngester{
+    params,
+  }
 }

--- a/lunatrace/bsl/ingest-worker/pkg/cisa/ingester.go
+++ b/lunatrace/bsl/ingest-worker/pkg/cisa/ingester.go
@@ -1,0 +1,215 @@
+// Copyright by LunaSec (owned by Refinery Labs, Inc)
+//
+// Licensed under the Business Source License v1.1
+// (the "License"); you may not use this file except in compliance with the
+// License. You may obtain a copy of the License at
+//
+// https://github.com/lunasec-io/lunasec/blob/master/licenses/BSL-LunaTrace.txt
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cisa
+
+import (
+  "context"
+  "database/sql"
+  "github.com/rs/zerolog/log"
+  "go.uber.org/fx"
+)
+
+type CISAKnownVulnIngester interface {
+  Ingest(ctx context.Context) error
+}
+
+type CISAKnownVulnIngesterParams struct {
+  fx.In
+
+  DB *sql.DB
+}
+
+type cisaKnownVulnIngester struct {
+  deps CISAKnownVulnIngesterParams
+}
+
+// -- Table to hold the CISA Known Exploited vulnerabilities
+// CREATE TABLE IF NOT EXISTS vulnerability.cisa_known_exploited_vulnerabilities (
+//     cve TEXT PRIMARY KEY,
+//     vendor_project text NOT NULL,
+//     product text NOT NULL,
+//     vulnerability_name text NOT NULL,
+//     date_added date NOT NULL,
+//     short_description text NOT NULL,
+//     required_action text NOT NULL,
+//     due_date date NOT NULL,
+//     notes text NOT NULL,
+//     CHECK (cve LIKE 'CVE-%')
+// );
+
+// GetKnownCves returns a list of all known CVEs from the database that exist in the CISA Known Exploited Vulnerabilities table
+// Run this query *after* you have inserted all the new CISA Known Exploited Vulnerabilities
+func GetKnownCves(tx *sql.Tx) (map[string]bool, error) {
+  // Query for all the CVEs that are already in the database from the CISA Known Vulnerabilitie
+  result, err := tx.Query(`
+    SELECT cve.id FROM vulnerability.cisa_known_exploited_vulnerabilities cisa
+    INNER JOIN vulnerability.vulnerability cve ON cve.source = 'nvd' AND cve.source_id = cisa.cve
+  `)
+  if err != nil {
+    log.Error().
+      Err(err).Msg("failed to query for known cves for CISA ingester")
+    return nil, err
+  }
+
+  knownCves := make(map[string]bool)
+  for result.Next() {
+    var cve string
+    err = result.Scan(&cve)
+    if err != nil {
+      log.Error().
+        Err(err).Msg("failed to map cve for CISA ingester")
+      return nil, err
+    }
+    knownCves[cve] = true
+  }
+  return knownCves, nil
+}
+
+func (s *cisaKnownVulnIngester) Ingest(ctx context.Context) error {
+
+  cisaKnownVulns, err := FetchCisaKnownVulns()
+  if err != nil {
+    log.Error().
+      Err(err)
+    return err
+  }
+
+  log.Info().
+    Int("count", len(cisaKnownVulns)).
+    Msg("fetched cisa known exploited vulnerabilities")
+
+  tx, err := s.deps.DB.BeginTx(ctx, &sql.TxOptions{
+    Isolation: sql.LevelReadUncommitted,
+  })
+  if err != nil {
+    return err
+  }
+  defer tx.Rollback()
+
+  for _, cisaKnownVuln := range cisaKnownVulns {
+    _, err = tx.ExecContext(ctx, `
+      INSERT INTO vulnerability.cisa_known_exploited_vulnerabilities (
+        cve,
+        vendor_project,
+        product,
+        vulnerability_name,
+        date_added,
+        short_description,
+        required_action,
+        due_date,
+        notes
+      ) VALUES (
+        $1, $2, $3, $4, $5, $6, $7, $8, $9
+      ) ON CONFLICT (cve) DO UPDATE SET
+        vendor_project = $2,
+        product = $3,
+        vulnerability_name = $4,
+        date_added = $5,
+        short_description = $6,
+        required_action = $7,
+        due_date = $8,
+        notes = $9
+      `,
+      cisaKnownVuln.Cve,
+      cisaKnownVuln.VendorProject,
+      cisaKnownVuln.Product,
+      cisaKnownVuln.VulnerabilityName,
+      cisaKnownVuln.DateAdded,
+      cisaKnownVuln.ShortDescription,
+      cisaKnownVuln.RequiredAction,
+      cisaKnownVuln.DueDate,
+      cisaKnownVuln.Notes,
+    )
+
+    if err != nil {
+      log.Error().
+        Err(err).Msg("failed to insert CISA Known Vulnerability")
+      return err
+    }
+  }
+
+  knownCves, err := GetKnownCves(tx)
+
+  if err != nil {
+    log.Error().
+      Err(err).Msg("failed to get known CVEs for CISA ingester")
+    return err
+  }
+
+  log.Info().
+    Int("knownCves", len(knownCves)).
+    Msg("found known CVEs, setting the cisa_known_exploited_cve column")
+
+  for _, cisaKnownVuln := range cisaKnownVulns {
+    if _, ok := knownCves[cisaKnownVuln.Cve]; ok {
+      continue
+    }
+
+    result, err := tx.QueryContext(ctx, `
+      SELECT cveeq.* FROM vulnerability.vulnerability cve
+        JOIN vulnerability.equivalent cveeq ON cveeq.a = cve.id OR cveeq.b = cve.id
+        WHERE cve.source = 'nvd' AND cve.source_id = $1
+    `, cisaKnownVuln.Cve)
+
+    if err != nil {
+      log.Error().
+        Err(err).Msg("failed to query for equivalent CVE for CISA ingester")
+      return err
+    }
+
+    // Generate a list of all vulnerabilities that need to be marked as being a CISA Known Exploited Vulnerability
+    cveIds := make(map[string]bool)
+    for result.Next() {
+      var cveA string
+      var cveB string
+      err = result.Scan(&cveA, &cveB)
+      if err != nil {
+        log.Error().
+          Err(err).Msg("failed to map equivalent CVE for CISA ingester")
+        return err
+      }
+
+      // add the CVEs to the map to ensure no duplicates
+      cveIds[cveA] = true
+      cveIds[cveB] = true
+    }
+
+    // Sets the CISA Known Exploited Vulnerability column for CVEs in the vulnerability table
+    for cveId := range cveIds {
+      _, err = tx.ExecContext(ctx, `
+        UPDATE vulnerability.vulnerability SET
+          cisa_known_exploited_cve = $1
+        WHERE id = $2
+      `, cisaKnownVuln.Cve, cveId)
+
+      if err != nil {
+        log.Error().
+          Err(err).Msg("failed to insert CISA Known Vulnerability")
+        return err
+      }
+    }
+  }
+
+  log.Info().
+    Msg("committing cisa known vulns")
+
+  if err = tx.Commit(); err != nil {
+    return err
+  }
+
+  return nil
+}
+
+func NewCISAKnownVulnIngester(params CISAKnownVulnIngesterParams) CISAKnownVulnIngester {
+  return &cisaKnownVulnIngester{
+    params,
+  }
+}

--- a/lunatrace/bsl/ingest-worker/pkg/cisa/ingester.go
+++ b/lunatrace/bsl/ingest-worker/pkg/cisa/ingester.go
@@ -11,24 +11,24 @@
 package cisa
 
 import (
-  "context"
-  "database/sql"
-  "github.com/rs/zerolog/log"
-  "go.uber.org/fx"
+	"context"
+	"database/sql"
+	"github.com/rs/zerolog/log"
+	"go.uber.org/fx"
 )
 
 type CISAKnownVulnIngester interface {
-  Ingest(ctx context.Context) error
+	Ingest(ctx context.Context) error
 }
 
 type CISAKnownVulnIngesterParams struct {
-  fx.In
+	fx.In
 
-  DB *sql.DB
+	DB *sql.DB
 }
 
 type cisaKnownVulnIngester struct {
-  deps CISAKnownVulnIngesterParams
+	deps CISAKnownVulnIngesterParams
 }
 
 // -- Table to hold the CISA Known Exploited vulnerabilities
@@ -48,54 +48,54 @@ type cisaKnownVulnIngester struct {
 // GetKnownCves returns a list of all known CVEs from the database that exist in the CISA Known Exploited Vulnerabilities table
 // Run this query *after* you have inserted all the new CISA Known Exploited Vulnerabilities
 func GetKnownCves(tx *sql.Tx) (map[string]bool, error) {
-  // Query for all the CVEs that are already in the database from the CISA Known Vulnerabilitie
-  result, err := tx.Query(`
+	// Query for all the CVEs that are already in the database from the CISA Known Vulnerabilitie
+	result, err := tx.Query(`
     SELECT cve.id FROM vulnerability.cisa_known_exploited_vulnerabilities cisa
     INNER JOIN vulnerability.vulnerability cve ON cve.source = 'nvd' AND cve.source_id = cisa.cve
   `)
-  if err != nil {
-    log.Error().
-      Err(err).Msg("failed to query for known cves for CISA ingester")
-    return nil, err
-  }
+	if err != nil {
+		log.Error().
+			Err(err).Msg("failed to query for known cves for CISA ingester")
+		return nil, err
+	}
 
-  knownCves := make(map[string]bool)
-  for result.Next() {
-    var cve string
-    err = result.Scan(&cve)
-    if err != nil {
-      log.Error().
-        Err(err).Msg("failed to map cve for CISA ingester")
-      return nil, err
-    }
-    knownCves[cve] = true
-  }
-  return knownCves, nil
+	knownCves := make(map[string]bool)
+	for result.Next() {
+		var cve string
+		err = result.Scan(&cve)
+		if err != nil {
+			log.Error().
+				Err(err).Msg("failed to map cve for CISA ingester")
+			return nil, err
+		}
+		knownCves[cve] = true
+	}
+	return knownCves, nil
 }
 
 func (s *cisaKnownVulnIngester) Ingest(ctx context.Context) error {
 
-  cisaKnownVulns, err := FetchCisaKnownVulns()
-  if err != nil {
-    log.Error().
-      Err(err)
-    return err
-  }
+	cisaKnownVulns, err := FetchCisaKnownVulns()
+	if err != nil {
+		log.Error().
+			Err(err)
+		return err
+	}
 
-  log.Info().
-    Int("count", len(cisaKnownVulns)).
-    Msg("fetched cisa known exploited vulnerabilities")
+	log.Info().
+		Int("count", len(cisaKnownVulns)).
+		Msg("fetched cisa known exploited vulnerabilities")
 
-  tx, err := s.deps.DB.BeginTx(ctx, &sql.TxOptions{
-    Isolation: sql.LevelReadUncommitted,
-  })
-  if err != nil {
-    return err
-  }
-  defer tx.Rollback()
+	tx, err := s.deps.DB.BeginTx(ctx, &sql.TxOptions{
+		Isolation: sql.LevelReadUncommitted,
+	})
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
 
-  for _, cisaKnownVuln := range cisaKnownVulns {
-    _, err = tx.ExecContext(ctx, `
+	for _, cisaKnownVuln := range cisaKnownVulns {
+		_, err = tx.ExecContext(ctx, `
       INSERT INTO vulnerability.cisa_known_exploited_vulnerabilities (
         cve,
         vendor_project,
@@ -118,98 +118,98 @@ func (s *cisaKnownVulnIngester) Ingest(ctx context.Context) error {
         due_date = $8,
         notes = $9
       `,
-      cisaKnownVuln.Cve,
-      cisaKnownVuln.VendorProject,
-      cisaKnownVuln.Product,
-      cisaKnownVuln.VulnerabilityName,
-      cisaKnownVuln.DateAdded,
-      cisaKnownVuln.ShortDescription,
-      cisaKnownVuln.RequiredAction,
-      cisaKnownVuln.DueDate,
-      cisaKnownVuln.Notes,
-    )
+			cisaKnownVuln.Cve,
+			cisaKnownVuln.VendorProject,
+			cisaKnownVuln.Product,
+			cisaKnownVuln.VulnerabilityName,
+			cisaKnownVuln.DateAdded,
+			cisaKnownVuln.ShortDescription,
+			cisaKnownVuln.RequiredAction,
+			cisaKnownVuln.DueDate,
+			cisaKnownVuln.Notes,
+		)
 
-    if err != nil {
-      log.Error().
-        Err(err).Msg("failed to insert CISA Known Vulnerability")
-      return err
-    }
-  }
+		if err != nil {
+			log.Error().
+				Err(err).Msg("failed to insert CISA Known Vulnerability")
+			return err
+		}
+	}
 
-  knownCves, err := GetKnownCves(tx)
+	knownCves, err := GetKnownCves(tx)
 
-  if err != nil {
-    log.Error().
-      Err(err).Msg("failed to get known CVEs for CISA ingester")
-    return err
-  }
+	if err != nil {
+		log.Error().
+			Err(err).Msg("failed to get known CVEs for CISA ingester")
+		return err
+	}
 
-  log.Info().
-    Int("knownCves", len(knownCves)).
-    Msg("found known CVEs, setting the cisa_known_exploited_cve column")
+	log.Info().
+		Int("knownCves", len(knownCves)).
+		Msg("found known CVEs, setting the cisa_known_exploited_cve column")
 
-  for _, cisaKnownVuln := range cisaKnownVulns {
-    if _, ok := knownCves[cisaKnownVuln.Cve]; ok {
-      continue
-    }
+	for _, cisaKnownVuln := range cisaKnownVulns {
+		if _, ok := knownCves[cisaKnownVuln.Cve]; ok {
+			continue
+		}
 
-    result, err := tx.QueryContext(ctx, `
+		result, err := tx.QueryContext(ctx, `
       SELECT cveeq.* FROM vulnerability.vulnerability cve
         JOIN vulnerability.equivalent cveeq ON cveeq.a = cve.id OR cveeq.b = cve.id
         WHERE cve.source = 'nvd' AND cve.source_id = $1
     `, cisaKnownVuln.Cve)
 
-    if err != nil {
-      log.Error().
-        Err(err).Msg("failed to query for equivalent CVE for CISA ingester")
-      return err
-    }
+		if err != nil {
+			log.Error().
+				Err(err).Msg("failed to query for equivalent CVE for CISA ingester")
+			return err
+		}
 
-    // Generate a list of all vulnerabilities that need to be marked as being a CISA Known Exploited Vulnerability
-    cveIds := make(map[string]bool)
-    for result.Next() {
-      var cveA string
-      var cveB string
-      err = result.Scan(&cveA, &cveB)
-      if err != nil {
-        log.Error().
-          Err(err).Msg("failed to map equivalent CVE for CISA ingester")
-        return err
-      }
+		// Generate a list of all vulnerabilities that need to be marked as being a CISA Known Exploited Vulnerability
+		cveIds := make(map[string]bool)
+		for result.Next() {
+			var cveA string
+			var cveB string
+			err = result.Scan(&cveA, &cveB)
+			if err != nil {
+				log.Error().
+					Err(err).Msg("failed to map equivalent CVE for CISA ingester")
+				return err
+			}
 
-      // add the CVEs to the map to ensure no duplicates
-      cveIds[cveA] = true
-      cveIds[cveB] = true
-    }
+			// add the CVEs to the map to ensure no duplicates
+			cveIds[cveA] = true
+			cveIds[cveB] = true
+		}
 
-    // Sets the CISA Known Exploited Vulnerability column for CVEs in the vulnerability table
-    for cveId := range cveIds {
-      _, err = tx.ExecContext(ctx, `
+		// Sets the CISA Known Exploited Vulnerability column for CVEs in the vulnerability table
+		for cveId := range cveIds {
+			_, err = tx.ExecContext(ctx, `
         UPDATE vulnerability.vulnerability SET
           cisa_known_exploited_cve = $1
         WHERE id = $2
       `, cisaKnownVuln.Cve, cveId)
 
-      if err != nil {
-        log.Error().
-          Err(err).Msg("failed to insert CISA Known Vulnerability")
-        return err
-      }
-    }
-  }
+			if err != nil {
+				log.Error().
+					Err(err).Msg("failed to insert CISA Known Vulnerability")
+				return err
+			}
+		}
+	}
 
-  log.Info().
-    Msg("committing cisa known vulns")
+	log.Info().
+		Msg("committing cisa known vulns")
 
-  if err = tx.Commit(); err != nil {
-    return err
-  }
+	if err = tx.Commit(); err != nil {
+		return err
+	}
 
-  return nil
+	return nil
 }
 
 func NewCISAKnownVulnIngester(params CISAKnownVulnIngesterParams) CISAKnownVulnIngester {
-  return &cisaKnownVulnIngester{
-    params,
-  }
+	return &cisaKnownVulnIngester{
+		params,
+	}
 }


### PR DESCRIPTION
This adds the ingester that downloads the latest CSV of the CISA Known Vulnerabilities, aka CVEs which are known to be exploited in the wild by attackers.

Tested this locally and there are only 10 vulnerabilities in our DB which we're missing in our DB, and they all seem to affect iOS devices only :)

You can test for all vulns not in the DB with this query:
```sql
-- Find all the CVEs that are not in the CISA list.
SELECT * FROM vulnerability.cisa_known_exploited_vulnerabilities cve
    WHERE NOT EXISTS (SELECT 1 FROM vulnerability.vulnerability v WHERE v.cisa_known_exploited_cve = cve.cve);
````

Screenshot from my IDE:
![Screenshot_2023-01-03_17-44-18](https://user-images.githubusercontent.com/4573221/210469270-4fab0a08-f1e8-4875-8f53-824a4be08ed8.png)
