### PR TITLE
Improve CVSS v3 backend parsing performances

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/Khan/genqlient v0.4.0
 	github.com/adrg/xdg v0.4.0
 	github.com/ajvpot/clifx v0.0.0-20220628211936-9cd4c559b7a3
+	github.com/anchore/go-logger v0.0.0-20220728155337-03b66a5207d8
 	github.com/anchore/grype v0.54.0
 	github.com/anchore/stereoscope v0.0.0-20221208011002-c5ff155d72f1
 	github.com/anchore/syft v0.63.0
@@ -22,7 +23,6 @@ require (
 	github.com/breadchris/ldapserver v1.1.0
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/dmarkham/enumer v1.5.5
-	github.com/facebookincubator/nvdtools v0.1.4
 	github.com/gin-gonic/gin v1.8.1
 	github.com/go-co-op/gocron v1.17.0
 	github.com/go-git/go-git/v5 v5.4.2
@@ -32,6 +32,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/lib/pq v1.10.7
 	github.com/lor00x/goldap v0.0.0-20180618054307-a546dffdd1a3
+	github.com/pandatix/go-cvss v0.5.1
 	github.com/pkg/errors v0.9.1
 	github.com/prashantv/gostub v1.1.0
 	github.com/prometheus/procfs v0.8.0
@@ -80,7 +81,6 @@ require (
 	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/alexflint/go-arg v1.4.2 // indirect
 	github.com/alexflint/go-scalar v1.0.0 // indirect
-	github.com/anchore/go-logger v0.0.0-20220728155337-03b66a5207d8 // indirect
 	github.com/anchore/go-macholibre v0.0.0-20220308212642-53e6d0aaf6fb // indirect
 	github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4 // indirect
 	github.com/anchore/packageurl-go v0.1.1-0.20220428202044-a072fa3cb6d7 // indirect
@@ -139,6 +139,7 @@ require (
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/envoyproxy/go-control-plane v0.10.3 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.6.7 // indirect
+	github.com/facebookincubator/nvdtools v0.1.4 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/fullstorydev/grpcurl v1.8.7 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1933,6 +1933,8 @@ github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
+github.com/pandatix/go-cvss v0.5.1 h1:k66hjCOGHmkx9LuJhslhjiuztNI0duaZPld5G13L4ec=
+github.com/pandatix/go-cvss v0.5.1/go.mod h1:7cu0TdcSUSyI8YB81OCx29RQlR7jXWqGLHywnII79SE=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/name v1.0.0 h1:n7LKFgHixETzxpRv2R77YgPUFo85QHGZKrdaYm7eY5U=

--- a/lunatrace/bsl/ingest-worker/pkg/vulnerability/advisory/osv.go
+++ b/lunatrace/bsl/ingest-worker/pkg/vulnerability/advisory/osv.go
@@ -12,19 +12,22 @@ package advisory
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-	"github.com/blang/semver/v4"
-	"github.com/facebookincubator/nvdtools/cvss3"
-	"github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/vulnerability/schema"
-	"github.com/lunasec-io/lunasec/lunatrace/cli/pkg/util"
-	"github.com/lunasec-io/lunasec/lunatrace/gogen/gql"
-	"github.com/lunasec-io/lunasec/lunatrace/gogen/gql/types"
-	"github.com/rs/zerolog/log"
-	"golang.org/x/exp/slices"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/blang/semver/v4"
+	"github.com/lunasec-io/lunasec/lunatrace/bsl/ingest-worker/pkg/vulnerability/schema"
+	"github.com/lunasec-io/lunasec/lunatrace/cli/pkg/util"
+	"github.com/lunasec-io/lunasec/lunatrace/gogen/gql"
+	"github.com/lunasec-io/lunasec/lunatrace/gogen/gql/types"
+	gocvss30 "github.com/pandatix/go-cvss/30"
+	gocvss31 "github.com/pandatix/go-cvss/31"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/exp/slices"
 )
 
 const (
@@ -214,7 +217,7 @@ func mapCvssScore(vuln *schema.OsvSchema) *float64 {
 		return nil
 	}
 
-	cvssVec, err := cvss3.VectorFromString(cvss3Severity.Score)
+	score, err := parseCVSS3(cvss3Severity.Score)
 	if err != nil {
 		log.Warn().
 			Err(err).
@@ -222,8 +225,30 @@ func mapCvssScore(vuln *schema.OsvSchema) *float64 {
 			Msg("unable to parse cvss severity")
 		return nil
 	}
-	score := cvssVec.Score()
-	return &score
+	return score
+}
+
+func parseCVSS3(vector string) (*float64, error) {
+	var score float64
+	switch {
+	case strings.HasPrefix(vector, "CVSS:3.0"):
+		vec, err := gocvss30.ParseVector(vector)
+		if err != nil {
+			return nil, err
+		}
+		score = vec.BaseScore()
+
+	case strings.HasPrefix(vector, "CVSS:3.1"):
+		vec, err := gocvss31.ParseVector(vector)
+		if err != nil {
+			return nil, err
+		}
+		score = vec.BaseScore()
+
+	default:
+		return nil, errors.New("unsupported CVSS version")
+	}
+	return &score, nil
 }
 
 func stringSlicePostgresqlArray(slice []string) string {


### PR DESCRIPTION
The [benchmarks of `github.com/pandatix/go-cvss`](https://github.com/pandatix/go-cvss#comparison) shows it better performs than `github.com/facebookincubator/nvdtools/cvss3`.
This improvement is a factor of 10 for times and allocations (`ns/op` and `allocs/op`, which decrease drastically the pressure on the Garbage Collector), and of a factor of 250 for memory consumption (`B/op`).

This improves the overall performances to help fulfill the contract of a 30 seconds scan.